### PR TITLE
chore(flake): Automatic flake updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1628735075,
-        "narHash": "sha256-4lO2/7vbfMZAI2SEtnsoqGrcBwmTi9sMJo9c3jyMOqg=",
+        "lastModified": 1629465813,
+        "narHash": "sha256-p4K+tYA3SR9JtVGxBdAQ8v1MZnKtkiWuPjjF1vtNpZo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f0f97b2fb60df3e47dbe3bcae60033e182092614",
+        "rev": "281948235a0441c2131edc28ab12569e9d757a9b",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1628808310,
-        "narHash": "sha256-Lo9xNydLgc0r6aJfsK5SdsJOUCpzvx0w4xXsF44kRkQ=",
+        "lastModified": 1629347633,
+        "narHash": "sha256-FGZJ7lmTAMIkjdrh6dIPck5HuB4KMT2GgDV5ZjiCWoc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a3d691c05308b43afe264a2165f60948cfd2963e",
+        "rev": "bf6b85136b47ab1a76df4a90ea4850871147494a",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1628696316,
-        "narHash": "sha256-SpafCjN4aWqS2zcBc70D8Y0idUJ7ZbNddYct+ucPOT4=",
+        "lastModified": 1629397698,
+        "narHash": "sha256-o57CMy5X8Xtw2pA1N3hYLxkXiL4M4x6hliMO3eFa6Gg=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "7d2233fad007a3dd42481f8ffc01e69b57a17f9e",
+        "rev": "2ae9ff128583984145ce38e61bbe9047871616bf",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1628756199,
-        "narHash": "sha256-yJTh8S4H9Y5IjsGm7GvVwOZ9Nbqvwp7bNd2GBQ8n7+A=",
+        "lastModified": 1629447323,
+        "narHash": "sha256-SQubghCqnw9ImPuE8Y7Dx1ie4Cuup0FlrMHYDby9UnQ=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "cc2d9d007daa953bddc336d4ad1deeed53a0a567",
+        "rev": "195f007a88792d433584323c1750b228765ac18f",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1628693817,
-        "narHash": "sha256-WtlM8ptjcUUWRvbpkToKJHzLlGCEXZKGh+SfwUYHobA=",
+        "lastModified": 1629292755,
+        "narHash": "sha256-5xMo32NVLnloY9DveqwJO/Cab1+PbTMPqU4WMmawX5M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9df2cb074d72ea80ac9fd225b29060c8cf13dd39",
+        "rev": "253aecf69ed7595aaefabde779aa6449195bebb7",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1628698409,
-        "narHash": "sha256-EgQ0ElIaWe3aglD0WhuZkOGY3ilSDEJtwgQaMI+P+l4=",
+        "lastModified": 1629411189,
+        "narHash": "sha256-HmJYvKrjDOUmRBQoV2iqy8pXqvDSNfITV3f0O0DfhD8=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "2511e1bc35abec0cd56695c2d52ff5e572576943",
+        "rev": "8dd3a71730161869d8da3694f3338042efa17d29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `fenix`: [`f0f97b2f` ➡️ `28194823`](https://github.com/nix-community/fenix/compare/f0f97b2fb60df3e47dbe3bcae60033e18209261..281948235a0441c2131edc28ab12569e9d757a9)
 - Updated `fenix/rust-analyzer-src`: [`2511e1bc` ➡️ `8dd3a717`](https://github.com/rust-analyzer/rust-analyzer/compare/2511e1bc35abec0cd56695c2d52ff5e57257694..8dd3a71730161869d8da3694f3338042efa17d2)
 - Updated `home-manager`: [`a3d691c0` ➡️ `bf6b8513`](https://github.com/nix-community/home-manager/compare/a3d691c05308b43afe264a2165f60948cfd2963..bf6b85136b47ab1a76df4a90ea4850871147494)
 - Updated `neovim-nightly`: [`cc2d9d00` ➡️ `195f007a`](https://github.com/nix-community/neovim-nightly-overlay/compare/cc2d9d007daa953bddc336d4ad1deeed53a0a56..195f007a88792d433584323c1750b228765ac18)
 - Updated `neovim-nightly/neovim-flake`: [`7d2233fa` ➡️ `2ae9ff12`](https://github.com/neovim/neovim/compare/7d2233fad007a3dd42481f8ffc01e69b57a17f9e..2ae9ff128583984145ce38e61bbe9047871616bf)
 - Updated `nixpkgs`: [`9df2cb07` ➡️ `253aecf6`](https://github.com/nixos/nixpkgs/compare/9df2cb074d72ea80ac9fd225b29060c8cf13dd3..253aecf69ed7595aaefabde779aa6449195bebb)