### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1629339842,
-        "narHash": "sha256-2MYl9QYgqmtT+sc8N+47bkUT3iiw8PzgX0LXyYWYYC4=",
+        "lastModified": 1629465813,
+        "narHash": "sha256-p4K+tYA3SR9JtVGxBdAQ8v1MZnKtkiWuPjjF1vtNpZo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "eb8ec69d2c31d416f8c5f6eacb1425a573961f10",
+        "rev": "281948235a0441c2131edc28ab12569e9d757a9b",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1629274242,
-        "narHash": "sha256-0qr6pFISilEh/1HsL3NAalRuc6/nJpHcWZx/G/NBkn4=",
+        "lastModified": 1629397698,
+        "narHash": "sha256-o57CMy5X8Xtw2pA1N3hYLxkXiL4M4x6hliMO3eFa6Gg=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "7bff642169438a66557b65d6aba80536eaf570fa",
+        "rev": "2ae9ff128583984145ce38e61bbe9047871616bf",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1629361007,
-        "narHash": "sha256-3dSHeYc7rG2sx21hmNzG5FIV27XuqBPCuRN9ImMm/NE=",
+        "lastModified": 1629447323,
+        "narHash": "sha256-SQubghCqnw9ImPuE8Y7Dx1ie4Cuup0FlrMHYDby9UnQ=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "ce1e960c55078fd4d51e4198a030a8f5bfc7454c",
+        "rev": "195f007a88792d433584323c1750b228765ac18f",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1629291893,
-        "narHash": "sha256-alfeAMGBBP3ZLDGucwW1LJcsF0x5VLn7T3jMwx2bFPU=",
+        "lastModified": 1629411189,
+        "narHash": "sha256-HmJYvKrjDOUmRBQoV2iqy8pXqvDSNfITV3f0O0DfhD8=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "ee4505f396249234bba05bfdbd14ae2a9d813004",
+        "rev": "8dd3a71730161869d8da3694f3338042efa17d29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `fenix`: [`eb8ec69d` ➡️ `28194823`](https://github.com/nix-community/fenix/compare/eb8ec69d2c31d416f8c5f6eacb1425a573961f1..281948235a0441c2131edc28ab12569e9d757a9)
 - Updated `fenix/rust-analyzer-src`: [`ee4505f3` ➡️ `8dd3a717`](https://github.com/rust-analyzer/rust-analyzer/compare/ee4505f396249234bba05bfdbd14ae2a9d81300..8dd3a71730161869d8da3694f3338042efa17d2)
 - Updated `neovim-nightly`: [`ce1e960c` ➡️ `195f007a`](https://github.com/nix-community/neovim-nightly-overlay/compare/ce1e960c55078fd4d51e4198a030a8f5bfc7454..195f007a88792d433584323c1750b228765ac18)
 - Updated `neovim-nightly/neovim-flake`: [`7bff6421` ➡️ `2ae9ff12`](https://github.com/neovim/neovim/compare/7bff642169438a66557b65d6aba80536eaf570fa..2ae9ff128583984145ce38e61bbe9047871616bf)