### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1630203910,
-        "narHash": "sha256-pxmCR2rYxcVXll0WA/nURyQ4zLlIWEVm530Rh7RnDgE=",
+        "lastModified": 1630808852,
+        "narHash": "sha256-9+0DlsIQApp+ikCVialLD8EKQMg/Sb8KXxoChUixau4=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "a487339fe891f9e3c9182ee4b1f03aa71f8075e0",
+        "rev": "b6d3e81ffab01f66f9f640d688809c2b6c31cf11",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1630030114,
-        "narHash": "sha256-t5lptbv7rtNSawdwoA2JUAiqXgLYAO+dGqp8KRtOaDA=",
+        "lastModified": 1630789937,
+        "narHash": "sha256-HEIrpDQ9Fevsx/4BQK2ZUW5AMq/GzhpfMaxyPlaSKyA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "33db7cc6a66d1c1cb77c23ae8e18cefd0425a0c8",
+        "rev": "2952168ed59aa369a560563de2e00eab19f42d1b",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1630117031,
-        "narHash": "sha256-O72Jv9oblwYrmPdiCC3+cBMwI8GhWuZAg+7ZeVctpog=",
+        "lastModified": 1630741170,
+        "narHash": "sha256-iew7IW+RiDuUWyxBSzg65zE+rldnoif2zgb/pe7gWBc=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "8af13ed946aa06636c633327c6549993e2e50116",
+        "rev": "61178778230e609d68b271ffd53ffd993cd23c42",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1630138306,
-        "narHash": "sha256-1tqJ6qO3A5FxrYVOq8hFCvEVn1PhKJFQUyaDeGbpXqU=",
+        "lastModified": 1630743112,
+        "narHash": "sha256-uG4LiFsz+MpLXNK2yn6Qm2AI5PG8yAI5PjenDCYhodQ=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "7a899330a1acd9ed6b3783cdecd256105e408a20",
+        "rev": "7600efa9cd318d3103c7e820bb1fd0f661ad77cb",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1630074300,
-        "narHash": "sha256-BFM7OiXRs0RvSUZd6NCGAKWVPn3VodgYQ4TUQXxbMBU=",
+        "lastModified": 1630761588,
+        "narHash": "sha256-7GXckvZy7DGh2KIyfdArqwnyeSc5Owy1fumEDQyd8eY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "21c937f8cb1e6adcfeb36dfd6c90d9d9bfab1d28",
+        "rev": "a51aa6523bd8ee985bc70987909eff235900197a",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1630178330,
-        "narHash": "sha256-EYSjLs9i5+b4Ea0O4QPnB/Y1eVD1ZgTzNkwr1yB53lo=",
+        "lastModified": 1630814844,
+        "narHash": "sha256-EyyedTUkYtconFcl6HPFI67qSS5Q5vUmNeS0rmsGCFE=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "d26888042ee2c1316a54f6a1b4f2804451effc70",
+        "rev": "863cd7787fc6608ead57a7b3beed1758276d07a0",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1630193914,
-        "narHash": "sha256-/HyJIq2NIEc/t2W1Vx6WfaTRlMwSFSLBoKN2pUj61SU=",
+        "lastModified": 1630776912,
+        "narHash": "sha256-jgyFeXMpBntmJqYTCSVOhhOZPlcUewtQUQQoTlZgbEs=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "7c7a41c5e9f1aae8a59994c22b366686e34486e5",
+        "rev": "c16e6474f9e4d11d967e5309735b0e673f4c24da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `fenix`: [`a487339f` ➡️ `b6d3e81f`](https://github.com/nix-community/fenix/compare/a487339fe891f9e3c9182ee4b1f03aa71f8075e..b6d3e81ffab01f66f9f640d688809c2b6c31cf1)
 - Updated `fenix/rust-analyzer-src`: [`7c7a41c5` ➡️ `c16e6474`](https://github.com/rust-analyzer/rust-analyzer/compare/7c7a41c5e9f1aae8a59994c22b366686e34486e..c16e6474f9e4d11d967e5309735b0e673f4c24d)
 - Updated `home-manager`: [`33db7cc6` ➡️ `2952168e`](https://github.com/nix-community/home-manager/compare/33db7cc6a66d1c1cb77c23ae8e18cefd0425a0c..2952168ed59aa369a560563de2e00eab19f42d1)
 - Updated `neovim-nightly`: [`7a899330` ➡️ `7600efa9`](https://github.com/nix-community/neovim-nightly-overlay/compare/7a899330a1acd9ed6b3783cdecd256105e408a2..7600efa9cd318d3103c7e820bb1fd0f661ad77c)
 - Updated `neovim-nightly/neovim-flake`: [`8af13ed9` ➡️ `61178778`](https://github.com/neovim/neovim/compare/8af13ed946aa06636c633327c6549993e2e50116..61178778230e609d68b271ffd53ffd993cd23c42)
 - Updated `neovim-nightly/neovim-flake/flake-utils`: [`f7e004a5` ➡️ `997f7efc`](https://github.com/numtide/flake-utils/compare/f7e004a55b120c02ecb6219596820fcd32ca877..997f7efcb746a9c140ce1f13c72263189225f48)
 - Updated `nixpkgs`: [`21c937f8` ➡️ `a51aa652`](https://github.com/nixos/nixpkgs/compare/21c937f8cb1e6adcfeb36dfd6c90d9d9bfab1d2..a51aa6523bd8ee985bc70987909eff235900197)
 - Updated `nur`: [`d2688804` ➡️ `863cd778`](https://github.com/nix-community/nur/compare/d26888042ee2c1316a54f6a1b4f2804451effc7..863cd7787fc6608ead57a7b3beed1758276d07a)