### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1630808852,
-        "narHash": "sha256-9+0DlsIQApp+ikCVialLD8EKQMg/Sb8KXxoChUixau4=",
+        "lastModified": 1631413610,
+        "narHash": "sha256-fOj1wzj0Cnw2IkMkj72RJaUdbnAOuSIDM/vNwktnZi0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "b6d3e81ffab01f66f9f640d688809c2b6c31cf11",
+        "rev": "c381eb6b673221b97cf7caf60ccd8fd34a0db4b3",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1630789937,
-        "narHash": "sha256-HEIrpDQ9Fevsx/4BQK2ZUW5AMq/GzhpfMaxyPlaSKyA=",
+        "lastModified": 1631134124,
+        "narHash": "sha256-C17wJ2HyuFZllJ/PbpFuuDjkzWvg8np9UIAdSrpuwS0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2952168ed59aa369a560563de2e00eab19f42d1b",
+        "rev": "039f786e609fdb3cfd9c5520ff3791750c3eaebf",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1630741170,
-        "narHash": "sha256-iew7IW+RiDuUWyxBSzg65zE+rldnoif2zgb/pe7gWBc=",
+        "lastModified": 1631326779,
+        "narHash": "sha256-/T3QznIhQFVdpQLGk24JDI8bfFiPQOJ6+Ly4G6meiE4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "61178778230e609d68b271ffd53ffd993cd23c42",
+        "rev": "086631cd92d7b60f122963f9fd1779583b19004c",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1630743112,
-        "narHash": "sha256-uG4LiFsz+MpLXNK2yn6Qm2AI5PG8yAI5PjenDCYhodQ=",
+        "lastModified": 1631347924,
+        "narHash": "sha256-JRVeXBlGp8eCic7HxEj/H9KEh9MLbbWq+rbMhDFLNkk=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "7600efa9cd318d3103c7e820bb1fd0f661ad77cb",
+        "rev": "3b416a38ba8f853aaeba9626712b3e64b85232c2",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1630761588,
-        "narHash": "sha256-7GXckvZy7DGh2KIyfdArqwnyeSc5Owy1fumEDQyd8eY=",
+        "lastModified": 1631295156,
+        "narHash": "sha256-jIriDkYUU09njpjvpRiS2/Yy+iKpmalCGJ2HnC41ZSQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a51aa6523bd8ee985bc70987909eff235900197a",
+        "rev": "bbbe2b35f736d039884e082ecc6d6e631e126029",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1630814844,
-        "narHash": "sha256-EyyedTUkYtconFcl6HPFI67qSS5Q5vUmNeS0rmsGCFE=",
+        "lastModified": 1631418460,
+        "narHash": "sha256-pDDxL3uAM7l9ptXB/Y0e0071BQVFm1lYiuzvF5t+sIY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "863cd7787fc6608ead57a7b3beed1758276d07a0",
+        "rev": "64707647f8f2d630220bd4fc6355b1e3069f70df",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1630776912,
-        "narHash": "sha256-jgyFeXMpBntmJqYTCSVOhhOZPlcUewtQUQQoTlZgbEs=",
+        "lastModified": 1631382595,
+        "narHash": "sha256-F7Vjg8kl4Rx9vNvReBeaVFLN1BigH0EXahcNFtDAvFc=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "c16e6474f9e4d11d967e5309735b0e673f4c24da",
+        "rev": "d270679997eb3aaf85de5173ff3276bc3c48fa41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `fenix`: [`b6d3e81f` ➡️ `c381eb6b`](https://github.com/nix-community/fenix/compare/b6d3e81ffab01f66f9f640d688809c2b6c31cf1..c381eb6b673221b97cf7caf60ccd8fd34a0db4b)
 - Updated `fenix/rust-analyzer-src`: [`c16e6474` ➡️ `d2706799`](https://github.com/rust-analyzer/rust-analyzer/compare/c16e6474f9e4d11d967e5309735b0e673f4c24d..d270679997eb3aaf85de5173ff3276bc3c48fa4)
 - Updated `home-manager`: [`2952168e` ➡️ `039f786e`](https://github.com/nix-community/home-manager/compare/2952168ed59aa369a560563de2e00eab19f42d1..039f786e609fdb3cfd9c5520ff3791750c3eaeb)
 - Updated `neovim-nightly`: [`7600efa9` ➡️ `3b416a38`](https://github.com/nix-community/neovim-nightly-overlay/compare/7600efa9cd318d3103c7e820bb1fd0f661ad77c..3b416a38ba8f853aaeba9626712b3e64b85232c)
 - Updated `neovim-nightly/neovim-flake`: [`61178778` ➡️ `086631cd`](https://github.com/neovim/neovim/compare/61178778230e609d68b271ffd53ffd993cd23c42..086631cd92d7b60f122963f9fd1779583b19004c)
 - Updated `nixpkgs`: [`a51aa652` ➡️ `bbbe2b35`](https://github.com/nixos/nixpkgs/compare/a51aa6523bd8ee985bc70987909eff235900197..bbbe2b35f736d039884e082ecc6d6e631e12602)
 - Updated `nur`: [`863cd778` ➡️ `64707647`](https://github.com/nix-community/nur/compare/863cd7787fc6608ead57a7b3beed1758276d07a..64707647f8f2d630220bd4fc6355b1e3069f70d)