### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1631413610,
-        "narHash": "sha256-fOj1wzj0Cnw2IkMkj72RJaUdbnAOuSIDM/vNwktnZi0=",
+        "lastModified": 1632018436,
+        "narHash": "sha256-rhlO4+SE1qjn/q4eOYCRJerwk1QYcA+kdufpgES7PL0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "c381eb6b673221b97cf7caf60ccd8fd34a0db4b3",
+        "rev": "8bd76e91a39e93f6da5ff50f3e7a63192e4d56a4",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1631134124,
-        "narHash": "sha256-C17wJ2HyuFZllJ/PbpFuuDjkzWvg8np9UIAdSrpuwS0=",
+        "lastModified": 1631740142,
+        "narHash": "sha256-FnwtaJ+fZw2QzsCqGJW4kJd9hXiPxPgfi+9dwratk28=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "039f786e609fdb3cfd9c5520ff3791750c3eaebf",
+        "rev": "371576cdc2580ba93a38e28da8ece2129f558815",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1631326779,
-        "narHash": "sha256-/T3QznIhQFVdpQLGk24JDI8bfFiPQOJ6+Ly4G6meiE4=",
+        "lastModified": 1631998863,
+        "narHash": "sha256-1wpuIebYz+PRojdCWTUn0hjcLm58VBWOWBZ03DXhD7I=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "086631cd92d7b60f122963f9fd1779583b19004c",
+        "rev": "924e8e4f2d88ee5c45e521e9f758b7c9f247a011",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1631347924,
-        "narHash": "sha256-JRVeXBlGp8eCic7HxEj/H9KEh9MLbbWq+rbMhDFLNkk=",
+        "lastModified": 1631999149,
+        "narHash": "sha256-+hSqL7zC5fDmmUIWD6TzkmS0rHGB6NO58OrXbnzg1Nc=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "3b416a38ba8f853aaeba9626712b3e64b85232c2",
+        "rev": "1543de288fb3608866c54d44303a8ff3d72b7ae3",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1631295156,
-        "narHash": "sha256-jIriDkYUU09njpjvpRiS2/Yy+iKpmalCGJ2HnC41ZSQ=",
+        "lastModified": 1631785487,
+        "narHash": "sha256-VSKEvOtaY/roDxEHFxXh6GguOqqWCJZ3E06fBdKu8+I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bbbe2b35f736d039884e082ecc6d6e631e126029",
+        "rev": "79c444b5bdeaba142d128afddee14c89ecf2a968",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1631418460,
-        "narHash": "sha256-pDDxL3uAM7l9ptXB/Y0e0071BQVFm1lYiuzvF5t+sIY=",
+        "lastModified": 1632017033,
+        "narHash": "sha256-NVU/9T/2S4Aoa1XYwtZgyW2IJDypnfN87D4bBqcWiZo=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "64707647f8f2d630220bd4fc6355b1e3069f70df",
+        "rev": "f2e2290dbf0f4359b1bf0076a1f48e9b7fc4c01d",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1631382595,
-        "narHash": "sha256-F7Vjg8kl4Rx9vNvReBeaVFLN1BigH0EXahcNFtDAvFc=",
+        "lastModified": 1631970591,
+        "narHash": "sha256-VcnO7+qY4Ek+sbdYtKjkKAnoDRE4p+TrdMbXlHE7EBw=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "d270679997eb3aaf85de5173ff3276bc3c48fa41",
+        "rev": "7729473dd24d27e55f931dac3b9dd0d11ff291e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `fenix`: [`c381eb6b` ➡️ `8bd76e91`](https://github.com/nix-community/fenix/compare/c381eb6b673221b97cf7caf60ccd8fd34a0db4b..8bd76e91a39e93f6da5ff50f3e7a63192e4d56a)
 - Updated `fenix/rust-analyzer-src`: [`d2706799` ➡️ `7729473d`](https://github.com/rust-analyzer/rust-analyzer/compare/d270679997eb3aaf85de5173ff3276bc3c48fa4..7729473dd24d27e55f931dac3b9dd0d11ff291e)
 - Updated `home-manager`: [`039f786e` ➡️ `371576cd`](https://github.com/nix-community/home-manager/compare/039f786e609fdb3cfd9c5520ff3791750c3eaeb..371576cdc2580ba93a38e28da8ece2129f55881)
 - Updated `neovim-nightly`: [`3b416a38` ➡️ `1543de28`](https://github.com/nix-community/neovim-nightly-overlay/compare/3b416a38ba8f853aaeba9626712b3e64b85232c..1543de288fb3608866c54d44303a8ff3d72b7ae)
 - Updated `neovim-nightly/neovim-flake`: [`086631cd` ➡️ `924e8e4f`](https://github.com/neovim/neovim/compare/086631cd92d7b60f122963f9fd1779583b19004c..924e8e4f2d88ee5c45e521e9f758b7c9f247a011)
 - Updated `nixpkgs`: [`bbbe2b35` ➡️ `79c444b5`](https://github.com/nixos/nixpkgs/compare/bbbe2b35f736d039884e082ecc6d6e631e12602..79c444b5bdeaba142d128afddee14c89ecf2a96)
 - Updated `nur`: [`64707647` ➡️ `f2e2290d`](https://github.com/nix-community/nur/compare/64707647f8f2d630220bd4fc6355b1e3069f70d..f2e2290dbf0f4359b1bf0076a1f48e9b7fc4c01)