### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1632018436,
-        "narHash": "sha256-rhlO4+SE1qjn/q4eOYCRJerwk1QYcA+kdufpgES7PL0=",
+        "lastModified": 1633141670,
+        "narHash": "sha256-+uijaBz8uRHqfzLj2CZlizBMFSNdkAUFLzePjoJ7NZY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8bd76e91a39e93f6da5ff50f3e7a63192e4d56a4",
+        "rev": "24731cb4716d4583e4db427f4320534389640fb5",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1631740142,
-        "narHash": "sha256-FnwtaJ+fZw2QzsCqGJW4kJd9hXiPxPgfi+9dwratk28=",
+        "lastModified": 1633210102,
+        "narHash": "sha256-TIGST5kvhV6xI6yyrdQHyzshcy534HqVEOMao4iJSxc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "371576cdc2580ba93a38e28da8ece2129f558815",
+        "rev": "0f3dfc94ef9f70cdb800e0cf8e22ec9d3a0a3c70",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1631998863,
-        "narHash": "sha256-1wpuIebYz+PRojdCWTUn0hjcLm58VBWOWBZ03DXhD7I=",
+        "lastModified": 1633153828,
+        "narHash": "sha256-QitN7URhwvQw6d+muZMNNVQsSrPExFP35u29+lDS+X0=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "924e8e4f2d88ee5c45e521e9f758b7c9f247a011",
+        "rev": "724ffe7095424e7acdbde8d0b12f357809561fdf",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1631999149,
-        "narHash": "sha256-+hSqL7zC5fDmmUIWD6TzkmS0rHGB6NO58OrXbnzg1Nc=",
+        "lastModified": 1633162334,
+        "narHash": "sha256-WYRh6FszrJtujdPf/LWGnRNGUA+SjwyaAtZOOr3vaH0=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "1543de288fb3608866c54d44303a8ff3d72b7ae3",
+        "rev": "85afd4dea0f6bb0384b355dc621c19c031b14535",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1631785487,
-        "narHash": "sha256-VSKEvOtaY/roDxEHFxXh6GguOqqWCJZ3E06fBdKu8+I=",
+        "lastModified": 1633080050,
+        "narHash": "sha256-T9I2WnlUzAIL70dk9V1jqaYk3nypy/cMkWR19S47ZHc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "79c444b5bdeaba142d128afddee14c89ecf2a968",
+        "rev": "82155ff501c7622cb2336646bb62f7624261f6d7",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1632017033,
-        "narHash": "sha256-NVU/9T/2S4Aoa1XYwtZgyW2IJDypnfN87D4bBqcWiZo=",
+        "lastModified": 1633226981,
+        "narHash": "sha256-aygSCXzd1X9Exk++gz6jK1NvyLzoVpEVpEJs7wvzGWk=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "f2e2290dbf0f4359b1bf0076a1f48e9b7fc4c01d",
+        "rev": "ddfc44de7293faadd101442fb17fbc4929be5aed",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1631970591,
-        "narHash": "sha256-VcnO7+qY4Ek+sbdYtKjkKAnoDRE4p+TrdMbXlHE7EBw=",
+        "lastModified": 1633118502,
+        "narHash": "sha256-dQQFD5Yw5KgsepO0gD6ttBmMQXxWZgWNe7wm+fZbVvg=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "7729473dd24d27e55f931dac3b9dd0d11ff291e4",
+        "rev": "237ea0d34dced3444486931f68e87cd07f52b6a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `fenix`: [`8bd76e91` ➡️ `24731cb4`](https://github.com/nix-community/fenix/compare/8bd76e91a39e93f6da5ff50f3e7a63192e4d56a..24731cb4716d4583e4db427f4320534389640fb)
 - Updated `fenix/rust-analyzer-src`: [`7729473d` ➡️ `237ea0d3`](https://github.com/rust-analyzer/rust-analyzer/compare/7729473dd24d27e55f931dac3b9dd0d11ff291e..237ea0d34dced3444486931f68e87cd07f52b6a)
 - Updated `home-manager`: [`371576cd` ➡️ `0f3dfc94`](https://github.com/nix-community/home-manager/compare/371576cdc2580ba93a38e28da8ece2129f55881..0f3dfc94ef9f70cdb800e0cf8e22ec9d3a0a3c7)
 - Updated `neovim-nightly`: [`1543de28` ➡️ `85afd4de`](https://github.com/nix-community/neovim-nightly-overlay/compare/1543de288fb3608866c54d44303a8ff3d72b7ae..85afd4dea0f6bb0384b355dc621c19c031b1453)
 - Updated `neovim-nightly/neovim-flake`: [`924e8e4f` ➡️ `724ffe70`](https://github.com/neovim/neovim/compare/924e8e4f2d88ee5c45e521e9f758b7c9f247a011..724ffe7095424e7acdbde8d0b12f357809561fdf)
 - Updated `nixpkgs`: [`79c444b5` ➡️ `82155ff5`](https://github.com/nixos/nixpkgs/compare/79c444b5bdeaba142d128afddee14c89ecf2a96..82155ff501c7622cb2336646bb62f7624261f6d)
 - Updated `nur`: [`f2e2290d` ➡️ `ddfc44de`](https://github.com/nix-community/nur/compare/f2e2290dbf0f4359b1bf0076a1f48e9b7fc4c01..ddfc44de7293faadd101442fb17fbc4929be5ae)