### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
-        "lastModified": 1638253217,
-        "narHash": "sha256-JURXPdXhClQNaZUBiZh+fFlqU7j1aoVaVeBah0sOdnk=",
+        "lastModified": 1638339898,
+        "narHash": "sha256-GlzXzo4DqNplANRkFFwPL3yOSPahaPwelHd82WwhWGI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "27d0917f0aee1b9e4fb743afe5aa832bc6f69ef7",
+        "rev": "244006069c86f0d010c6e547eda8d4e6c3d7f0a5",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638150501,
-        "narHash": "sha256-aWH3MRmjUtx8ciSGLegBJC5mhymsuroHPs74ZldrNTU=",
+        "lastModified": 1638311312,
+        "narHash": "sha256-OMAd3WZ/VtMK0QQwDrrynP6+jOlWLd1yQtnW56+eZtA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9de77227d7780518cfeaee5a917970247f3ecc56",
+        "rev": "f23073f1daa769a28a12ac587eea487aa8afb196",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1638225475,
-        "narHash": "sha256-6cSHVWt+OhDSWb4R9peIeON+T4sgx4nIHi6dVegmfe8=",
+        "lastModified": 1638329954,
+        "narHash": "sha256-xYlTATWAX9Vu0yK39mFO4UX0Yl/Xz3if+/a7iAV3kV8=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "fff8827908494a9c4bd5de10c409189929b3db56",
+        "rev": "d3585e0ec52ee828fd68c4bd3e3ec1c294e1f4a0",
         "type": "github"
       },
       "original": {
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638259930,
-        "narHash": "sha256-02wtdpYf6t+8ArYZw3gEByZ0Ze6NaC74eeMmJqUeEO8=",
+        "lastModified": 1638346476,
+        "narHash": "sha256-n6gMG7+3C2DjpvzwRYC1Ag3QsfovJPKPj5Ds3LOTXg0=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "8266624fcbf1218cd3b42cbeb51972c326c06629",
+        "rev": "3099b910be69b6e9c1bf00b25df9de2932d5318f",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1638198142,
-        "narHash": "sha256-plU9b8r4St6q4U7VHtG9V7oF8k9fIpfXl/KDaZLuY9k=",
+        "lastModified": 1638286143,
+        "narHash": "sha256-A+rgjbIpz3uPRKHPXwdmouVcVn5pZqLnaZHymjkraG4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a308775674e178495767df90c419425474582a1",
+        "rev": "29d1f6e1f625d246dcf84a78ef97b4da3cafc6ea",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1638301878,
-        "narHash": "sha256-kKWXCLFI2vZtCrJXnh+kjrL2LFMc3P/b/CopLshy3cQ=",
+        "lastModified": 1638353583,
+        "narHash": "sha256-ZU7yOeonlQz3Q71Qap/oyH8y13yTcbslxgcWMMeXyOM=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "f35a53925a009966b0922d122dc1acb0f7ed2729",
+        "rev": "0e66481681f241ff17a6ba085fa8b18a3d06b8eb",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
     "rust-analyzer-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1638223384,
-        "narHash": "sha256-fa1JCHbx7Oge0eAPOVoHJkUSzueXNh21AdUZbvh6RAI=",
+        "lastModified": 1638281259,
+        "narHash": "sha256-KbquiOMt0TJLIGj0vAGKA3AOGjTMtB3fOO8bxxN2Sns=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "e217632b9819876cd59f4f6f963d04b0637bd8d2",
+        "rev": "2d0db312b543343f1c208b6be21a7a001cec7dd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `fenix`: [`27d0917f` ➡️ `24400606`](https://github.com/nix-community/fenix/compare/27d0917f0aee1b9e4fb743afe5aa832bc6f69ef..244006069c86f0d010c6e547eda8d4e6c3d7f0a)
 - Updated `fenix/rust-analyzer-src`: [`e217632b` ➡️ `2d0db312`](https://github.com/rust-analyzer/rust-analyzer/compare/e217632b9819876cd59f4f6f963d04b0637bd8d..2d0db312b543343f1c208b6be21a7a001cec7dd)
 - Updated `home-manager`: [`9de77227` ➡️ `f23073f1`](https://github.com/nix-community/home-manager/compare/9de77227d7780518cfeaee5a917970247f3ecc5..f23073f1daa769a28a12ac587eea487aa8afb19)
 - Updated `neovim-nightly`: [`8266624f` ➡️ `3099b910`](https://github.com/nix-community/neovim-nightly-overlay/compare/8266624fcbf1218cd3b42cbeb51972c326c0662..3099b910be69b6e9c1bf00b25df9de2932d5318)
 - Updated `neovim-nightly/neovim-flake`: [`fff88279` ➡️ `d3585e0e`](https://github.com/neovim/neovim/compare/fff8827908494a9c4bd5de10c409189929b3db56..d3585e0ec52ee828fd68c4bd3e3ec1c294e1f4a0)
 - Updated `nixpkgs`: [`8a308775` ➡️ `29d1f6e1`](https://github.com/nixos/nixpkgs/compare/8a308775674e178495767df90c419425474582a..29d1f6e1f625d246dcf84a78ef97b4da3cafc6e)
 - Updated `nur`: [`f35a5392` ➡️ `0e664816`](https://github.com/nix-community/nur/compare/f35a53925a009966b0922d122dc1acb0f7ed272..0e66481681f241ff17a6ba085fa8b18a3d06b8e)