### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1637008234,
-        "narHash": "sha256-unxR6KYdOxc27rvGRKIl6a9AHvgAES89uJDM1FYQzfc=",
+        "lastModified": 1639081916,
+        "narHash": "sha256-SI564NfvFK9idNHa6/x4HktojDXslE/syO0QhK8r4rs=",
         "owner": "elkowar",
         "repo": "eww",
-        "rev": "fc06db07043f4fb82d029fcb420e1e68d1bbe74e",
+        "rev": "5e5692742e046a97e3da3a5e19c50c331403c115",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
-        "lastModified": 1638339898,
-        "narHash": "sha256-GlzXzo4DqNplANRkFFwPL3yOSPahaPwelHd82WwhWGI=",
+        "lastModified": 1639203847,
+        "narHash": "sha256-YBDiWZO5UHkR8Mu2543sbOsgsB4M91JQjrPwMhDYM0g=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "244006069c86f0d010c6e547eda8d4e6c3d7f0a5",
+        "rev": "26f1d2d833dd2dc2c8b839cf5db3bb0732558398",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638311312,
-        "narHash": "sha256-OMAd3WZ/VtMK0QQwDrrynP6+jOlWLd1yQtnW56+eZtA=",
+        "lastModified": 1639246679,
+        "narHash": "sha256-Jom+l4fklkb3/wxITqz5FrOd4LeL47Eg55xmxo1fY2g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f23073f1daa769a28a12ac587eea487aa8afb196",
+        "rev": "0ebed30a10617bd48dd1bd0ce8697aab1b42d933",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1638329954,
-        "narHash": "sha256-xYlTATWAX9Vu0yK39mFO4UX0Yl/Xz3if+/a7iAV3kV8=",
+        "lastModified": 1639175880,
+        "narHash": "sha256-G2O/ViPfnLYCA/GriyN1HdIdU5COSCF1SVGSy1TGB+I=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "d3585e0ec52ee828fd68c4bd3e3ec1c294e1f4a0",
+        "rev": "3f8703093de56254ffdbf8ef6ddbe7942af54257",
         "type": "github"
       },
       "original": {
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638346476,
-        "narHash": "sha256-n6gMG7+3C2DjpvzwRYC1Ag3QsfovJPKPj5Ds3LOTXg0=",
+        "lastModified": 1639210387,
+        "narHash": "sha256-5HiroEpFRN5tG88X5ZWM7K+Pr2Q5bYmzJhgKVVbbhYg=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "3099b910be69b6e9c1bf00b25df9de2932d5318f",
+        "rev": "f38af8005370113e959c111ec8723450bb50f8b8",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1638286143,
-        "narHash": "sha256-A+rgjbIpz3uPRKHPXwdmouVcVn5pZqLnaZHymjkraG4=",
+        "lastModified": 1638986258,
+        "narHash": "sha256-OceRdctKZRSgqQxVRvvNB0MaEnFMzQqjUffecoDE9eI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29d1f6e1f625d246dcf84a78ef97b4da3cafc6ea",
+        "rev": "581d2d6c9cd5c289002203581d8aa0861963a933",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1638353583,
-        "narHash": "sha256-ZU7yOeonlQz3Q71Qap/oyH8y13yTcbslxgcWMMeXyOM=",
+        "lastModified": 1639282094,
+        "narHash": "sha256-L0Te5kbspUI9dMiy9qabuCnMAnxT9x42kP8KGzaE48w=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "0e66481681f241ff17a6ba085fa8b18a3d06b8eb",
+        "rev": "7abddc16582e8c28e4ab48e6cf93908b60e7c59a",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
     "rust-analyzer-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1638281259,
-        "narHash": "sha256-KbquiOMt0TJLIGj0vAGKA3AOGjTMtB3fOO8bxxN2Sns=",
+        "lastModified": 1639175515,
+        "narHash": "sha256-Yj38u9BpKfyGrcSEaoSEnOns885xn/Ask6lR5rsxS8k=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "2d0db312b543343f1c208b6be21a7a001cec7dd6",
+        "rev": "d03397fe1173eaeb2e04c9e55ac223289e7e08ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `eww`: [`fc06db07` ➡️ `5e569274`](https://github.com/elkowar/eww/compare/fc06db07043f4fb82d029fcb420e1e68d1bbe74..5e5692742e046a97e3da3a5e19c50c331403c11)
 - Updated `fenix`: [`24400606` ➡️ `26f1d2d8`](https://github.com/nix-community/fenix/compare/244006069c86f0d010c6e547eda8d4e6c3d7f0a..26f1d2d833dd2dc2c8b839cf5db3bb073255839)
 - Updated `fenix/rust-analyzer-src`: [`2d0db312` ➡️ `d03397fe`](https://github.com/rust-analyzer/rust-analyzer/compare/2d0db312b543343f1c208b6be21a7a001cec7dd..d03397fe1173eaeb2e04c9e55ac223289e7e08e)
 - Updated `home-manager`: [`f23073f1` ➡️ `0ebed30a`](https://github.com/nix-community/home-manager/compare/f23073f1daa769a28a12ac587eea487aa8afb19..0ebed30a10617bd48dd1bd0ce8697aab1b42d93)
 - Updated `neovim-nightly`: [`3099b910` ➡️ `f38af800`](https://github.com/nix-community/neovim-nightly-overlay/compare/3099b910be69b6e9c1bf00b25df9de2932d5318..f38af8005370113e959c111ec8723450bb50f8b)
 - Updated `neovim-nightly/neovim-flake`: [`d3585e0e` ➡️ `3f870309`](https://github.com/neovim/neovim/compare/d3585e0ec52ee828fd68c4bd3e3ec1c294e1f4a0..3f8703093de56254ffdbf8ef6ddbe7942af54257)
 - Updated `nixpkgs`: [`29d1f6e1` ➡️ `581d2d6c`](https://github.com/nixos/nixpkgs/compare/29d1f6e1f625d246dcf84a78ef97b4da3cafc6e..581d2d6c9cd5c289002203581d8aa0861963a93)
 - Updated `nur`: [`0e664816` ➡️ `7abddc16`](https://github.com/nix-community/nur/compare/0e66481681f241ff17a6ba085fa8b18a3d06b8e..7abddc16582e8c28e4ab48e6cf93908b60e7c59)