### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
-        "lastModified": 1639203847,
-        "narHash": "sha256-YBDiWZO5UHkR8Mu2543sbOsgsB4M91JQjrPwMhDYM0g=",
+        "lastModified": 1639808710,
+        "narHash": "sha256-OKDHt4D14puuqfVHptQ6EvjIR9RaHXyPzMh8Rjo8vzA=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "26f1d2d833dd2dc2c8b839cf5db3bb0732558398",
+        "rev": "9b391fc1831ece6c245a4eafe7b52f5c806df28c",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639246679,
-        "narHash": "sha256-Jom+l4fklkb3/wxITqz5FrOd4LeL47Eg55xmxo1fY2g=",
+        "lastModified": 1639774225,
+        "narHash": "sha256-pdXvYneQVzB14fD+Q283s17tXRyQMs2JMx4mZ4JeSYg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0ebed30a10617bd48dd1bd0ce8697aab1b42d933",
+        "rev": "8b44e81978a2bef60c83ecc0199ab2523310214a",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1639175880,
-        "narHash": "sha256-G2O/ViPfnLYCA/GriyN1HdIdU5COSCF1SVGSy1TGB+I=",
+        "lastModified": 1639795113,
+        "narHash": "sha256-pVBNbtpamfSOM3eBZWn/Xx9V9FwRaYw7WZ+yOUyz2UA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "3f8703093de56254ffdbf8ef6ddbe7942af54257",
+        "rev": "818ae74eaf6f4538ca61ee4ba703543b0caaff10",
         "type": "github"
       },
       "original": {
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639210387,
-        "narHash": "sha256-5HiroEpFRN5tG88X5ZWM7K+Pr2Q5bYmzJhgKVVbbhYg=",
+        "lastModified": 1639846990,
+        "narHash": "sha256-vjB3NUJfD6HZS0TaGbK22Gw1d5NdBZlsNI1k2zonogE=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "f38af8005370113e959c111ec8723450bb50f8b8",
+        "rev": "a299989784567908c8e26877341f9965a93c1d91",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1638986258,
-        "narHash": "sha256-OceRdctKZRSgqQxVRvvNB0MaEnFMzQqjUffecoDE9eI=",
+        "lastModified": 1639699734,
+        "narHash": "sha256-tlX6WebGmiHb2Hmniff+ltYp+7dRfdsBxw9YczLsP60=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "581d2d6c9cd5c289002203581d8aa0861963a933",
+        "rev": "03ec468b14067729a285c2c7cfa7b9434a04816c",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1639282094,
-        "narHash": "sha256-L0Te5kbspUI9dMiy9qabuCnMAnxT9x42kP8KGzaE48w=",
+        "lastModified": 1639889265,
+        "narHash": "sha256-9uz1sgTqxRl1KzKeRnBR1fRmVqRRP+xJGkggMbMpM60=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "7abddc16582e8c28e4ab48e6cf93908b60e7c59a",
+        "rev": "5182a52981d350d44a5160ef8ab4c765e5fe40a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `fenix`: [`26f1d2d8` ➡️ `9b391fc1`](https://github.com/nix-community/fenix/compare/26f1d2d833dd2dc2c8b839cf5db3bb073255839..9b391fc1831ece6c245a4eafe7b52f5c806df28)
 - Updated `home-manager`: [`0ebed30a` ➡️ `8b44e819`](https://github.com/nix-community/home-manager/compare/0ebed30a10617bd48dd1bd0ce8697aab1b42d93..8b44e81978a2bef60c83ecc0199ab2523310214)
 - Updated `neovim-nightly`: [`f38af800` ➡️ `a2999897`](https://github.com/nix-community/neovim-nightly-overlay/compare/f38af8005370113e959c111ec8723450bb50f8b..a299989784567908c8e26877341f9965a93c1d9)
 - Updated `neovim-nightly/neovim-flake`: [`3f870309` ➡️ `818ae74e`](https://github.com/neovim/neovim/compare/3f8703093de56254ffdbf8ef6ddbe7942af54257..818ae74eaf6f4538ca61ee4ba703543b0caaff10)
 - Updated `nixpkgs`: [`581d2d6c` ➡️ `03ec468b`](https://github.com/nixos/nixpkgs/compare/581d2d6c9cd5c289002203581d8aa0861963a93..03ec468b14067729a285c2c7cfa7b9434a04816)
 - Updated `nur`: [`7abddc16` ➡️ `5182a529`](https://github.com/nix-community/nur/compare/7abddc16582e8c28e4ab48e6cf93908b60e7c59..5182a52981d350d44a5160ef8ab4c765e5fe40a)