### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1634994402,
-        "narHash": "sha256-xmlCVVOYGpZoxgOqsDOVF0B0ASrnbNGVAEzID9qh2xo=",
+        "lastModified": 1641152326,
+        "narHash": "sha256-yQXzXrjrilGzBjC+2kZVPZRgBPSdCLovSLmJ7Na7EDo=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "44da835ac40dab5fd231298b59d83487382d2fab",
+        "rev": "15635ae63878b83598a18ae421e8c819b691dc55",
         "type": "github"
       },
       "original": {
@@ -27,14 +27,14 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1639081916,
-        "narHash": "sha256-SI564NfvFK9idNHa6/x4HktojDXslE/syO0QhK8r4rs=",
+        "lastModified": 1639928775,
+        "narHash": "sha256-VntDl7JaIfvn3pd+2uDocnXFRkPnQQbRkYDn4XWeC5o=",
         "owner": "elkowar",
         "repo": "eww",
-        "rev": "5e5692742e046a97e3da3a5e19c50c331403c115",
+        "rev": "106106ade31e7cc669f2ae53f24191cd0a683c39",
         "type": "github"
       },
       "original": {
@@ -45,7 +45,9 @@
     },
     "fenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
@@ -70,11 +72,11 @@
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
-        "lastModified": 1639808710,
-        "narHash": "sha256-OKDHt4D14puuqfVHptQ6EvjIR9RaHXyPzMh8Rjo8vzA=",
+        "lastModified": 1641623160,
+        "narHash": "sha256-4k7fkAopJzHpJ5Sxk1SmZeXBEeo0XjNqA6SMIaEFQkY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "9b391fc1831ece6c245a4eafe7b52f5c806df28c",
+        "rev": "5312f44f270c6e4bf5a2249d9ef5c4d1bff5bd36",
         "type": "github"
       },
       "original": {
@@ -102,11 +104,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
         "type": "github"
       },
       "original": {
@@ -118,11 +120,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
         "type": "github"
       },
       "original": {
@@ -168,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639774225,
-        "narHash": "sha256-pdXvYneQVzB14fD+Q283s17tXRyQMs2JMx4mZ4JeSYg=",
+        "lastModified": 1641700429,
+        "narHash": "sha256-+Pd33S+4+VX6RYGJQ5Q4n46+iRLr9y9ilq9oC/bcnoc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8b44e81978a2bef60c83ecc0199ab2523310214a",
+        "rev": "a90ddcd62748e445bbbe01834595eda29dc28db9",
         "type": "github"
       },
       "original": {
@@ -183,7 +185,7 @@
     },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1629707199,
@@ -202,15 +204,17 @@
     "neovim-flake": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1639795113,
-        "narHash": "sha256-pVBNbtpamfSOM3eBZWn/Xx9V9FwRaYw7WZ+yOUyz2UA=",
+        "lastModified": 1641608227,
+        "narHash": "sha256-gZRC0mQxQ0nzE2BaFd/9qi+dRLaWbs1PMs7oRlCkVzA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "818ae74eaf6f4538ca61ee4ba703543b0caaff10",
+        "rev": "e92b816336a04c18c4aa78eb180158a2bc02ace4",
         "type": "github"
       },
       "original": {
@@ -229,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639846990,
-        "narHash": "sha256-vjB3NUJfD6HZS0TaGbK22Gw1d5NdBZlsNI1k2zonogE=",
+        "lastModified": 1641629662,
+        "narHash": "sha256-u28frvoAXYBRmrbFkuWaA0zJZXzR+0ZKj1IAW3i8UdM=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "a299989784567908c8e26877341f9965a93c1d91",
+        "rev": "5dd1bc1899c8ec4e4b70bb947651e9f450e6a738",
         "type": "github"
       },
       "original": {
@@ -243,22 +247,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1640540585,
-        "narHash": "sha256-cCmknKFjWgam9jq+58wSd0Z4REia8mjBP65kXcL3ki8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ac169ec6371f0d835542db654a65e0f2feb07838",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1630761588,
         "narHash": "sha256-7GXckvZy7DGh2KIyfdArqwnyeSc5Owy1fumEDQyd8eY=",
@@ -271,7 +259,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1630140382,
         "narHash": "sha256-ntXepAHFlAEtaYIU5EzckRUODeeMgpu1u2Yug+4LFNc=",
@@ -286,29 +274,13 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
-        "lastModified": 1640540585,
-        "narHash": "sha256-cCmknKFjWgam9jq+58wSd0Z4REia8mjBP65kXcL3ki8=",
+        "lastModified": 1641528457,
+        "narHash": "sha256-FyU9E63n1W7Ql4pMnhW2/rO9OftWZ37pLppn/c1aisY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ac169ec6371f0d835542db654a65e0f2feb07838",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1639699734,
-        "narHash": "sha256-tlX6WebGmiHb2Hmniff+ltYp+7dRfdsBxw9YczLsP60=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "03ec468b14067729a285c2c7cfa7b9434a04816c",
+        "rev": "ff377a78794d412a35245e05428c8f95fef3951f",
         "type": "github"
       },
       "original": {
@@ -320,11 +292,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1639889265,
-        "narHash": "sha256-9uz1sgTqxRl1KzKeRnBR1fRmVqRRP+xJGkggMbMpM60=",
+        "lastModified": 1641701100,
+        "narHash": "sha256-bYrTWA8a6zc8lBKyG4YKaXPqvN4hVps6yWNeyj6aVuw=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "5182a52981d350d44a5160ef8ab4c765e5fe40a1",
+        "rev": "e78eb8016f2b1b20298367804085d6d147557ba0",
         "type": "github"
       },
       "original": {
@@ -341,7 +313,7 @@
         "flake-compat": "flake-compat_2",
         "home-manager": "home-manager",
         "neovim-nightly": "neovim-nightly",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_3",
         "nur": "nur"
       }
     },
@@ -365,11 +337,11 @@
     "rust-analyzer-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1639175515,
-        "narHash": "sha256-Yj38u9BpKfyGrcSEaoSEnOns885xn/Ask6lR5rsxS8k=",
+        "lastModified": 1641588777,
+        "narHash": "sha256-6q7tG714eiglUTgWvrJ0c73cv7VtnY1NEB4lHfI77ZY=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "d03397fe1173eaeb2e04c9e55ac223289e7e08ee",
+        "rev": "54c999893396434725c284fdcfeeb4d47340d53f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake input changes:

 - Updated `darwin`: [`44da835a` ➡️ `15635ae6`](https://github.com/lnl7/nix-darwin/compare/44da835ac40dab5fd231298b59d83487382d2fa..15635ae63878b83598a18ae421e8c819b691dc5)
 - Updated `eww`: [`5e569274` ➡️ `106106ad`](https://github.com/elkowar/eww/compare/5e5692742e046a97e3da3a5e19c50c331403c11..106106ade31e7cc669f2ae53f24191cd0a683c3)
 - Updated `eww/fenix/nixpkgs`: [`ac169ec6` ➡️ ``](https://github.com/nixos/nixpkgs/compare/ac169ec6371f0d835542db654a65e0f2feb0783..)
 - Updated `fenix`: [`9b391fc1` ➡️ `43fa9944`](https://github.com/nix-community/fenix/compare/9b391fc1831ece6c245a4eafe7b52f5c806df28..43fa994400794b5cb09ab9be894372c9e51bf7a)
 - Updated `fenix/rust-analyzer-src`: [`d03397fe` ➡️ `0f8c96c9`](https://github.com/rust-analyzer/rust-analyzer/compare/d03397fe1173eaeb2e04c9e55ac223289e7e08e..0f8c96c92689af8378dbe9f466c6bf15a3a2745)
 - Updated `flake-compat`: [`12c64ca5` ➡️ `b7547d3e`](https://github.com/edolstra/flake-compat/compare/12c64ca55c1014cdc1b16ed5a804aa8576601ff..b7547d3eed6f32d06102ead8991ec52ab0a4f1a)
 - Updated `home-manager`: [`8b44e819` ➡️ `f3be3cda`](https://github.com/nix-community/home-manager/compare/8b44e81978a2bef60c83ecc0199ab2523310214..f3be3cda6a69365f2acecc201b3cd1ee4f6d461)
 - Updated `neovim-nightly`: [`a2999897` ➡️ `f77aec20`](https://github.com/nix-community/neovim-nightly-overlay/compare/a299989784567908c8e26877341f9965a93c1d9..f77aec20552f9638aa7226b364123535c351fc9)
 - Updated `neovim-nightly/flake-compat`: [`12c64ca5` ➡️ `b7547d3e`](https://github.com/edolstra/flake-compat/compare/12c64ca55c1014cdc1b16ed5a804aa8576601ff..b7547d3eed6f32d06102ead8991ec52ab0a4f1a)
 - Updated `neovim-nightly/neovim-flake`: [`818ae74e` ➡️ `8f27c4a0`](https://github.com/neovim/neovim/compare/818ae74eaf6f4538ca61ee4ba703543b0caaff10..8f27c4a0417c001fa2dedb6346673da501ea78e5)
 - Updated `neovim-nightly/neovim-flake/nixpkgs`: [`ac169ec6` ➡️ ``](https://github.com/nixos/nixpkgs/compare/ac169ec6371f0d835542db654a65e0f2feb0783..)
 - Updated `nixpkgs`: [`03ec468b` ➡️ `0ecf7d41`](https://github.com/nixos/nixpkgs/compare/03ec468b14067729a285c2c7cfa7b9434a04816..0ecf7d414811f831060cf55707c374d54fbb1de)
 - Updated `nur`: [`5182a529` ➡️ `c593ce51`](https://github.com/nix-community/nur/compare/5182a52981d350d44a5160ef8ab4c765e5fe40a..c593ce514bdbc523ae3867ba3627c1bb547fa95)