### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1643178253,
-        "narHash": "sha256-8E2Gv9d8iZWChZ1EdXeDkNrXTJCn5vvBKVvocZTdoC0=",
+        "lastModified": 1643610217,
+        "narHash": "sha256-3cFZt9Eyz70s1CNYO3wJeUDgLUC9tC4s5hNpLtX3FQY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d81537d2ea5cd1e9866f8e58a7b756a4b2a5070c",
+        "rev": "bd91b6fddf7fdf90ad9924339fcb40f008f57447",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643151280,
-        "narHash": "sha256-sVlOWjDm+QU9vIjY+awfOwB5T/Sl8R+LkP9sNXhVCw4=",
+        "lastModified": 1643567433,
+        "narHash": "sha256-tyFgodcZRlt0ZshbgyLf4m/Sd/ys9p0AHfeVZQ50WKU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "990ca662c4b92636053ea399f5fb80702830522c",
+        "rev": "95d39e13a4a7a818c87f2701b59820d3ac0e674c",
         "type": "github"
       },
       "original": {
@@ -112,15 +112,18 @@
     "neovim-flake": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "neovim-nightly",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1643095335,
-        "narHash": "sha256-NgrojDU8ziCZ6ImaD4xJ+6zw7OoWZSgiZYoD7dWCSVE=",
+        "lastModified": 1643591050,
+        "narHash": "sha256-tymKSBi5/ITW6+/u1hKDpWPI0Qx1Ibhu/rhtcVul17c=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "ecec957125ca95ef5fbc4534d62ed16cfedb0c44",
+        "rev": "2870311a37314135b73e0ee54b41da86c9540a39",
         "type": "github"
       },
       "original": {
@@ -139,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643184788,
-        "narHash": "sha256-CEegWL0dzfhfWTdnMRK7A/DWh7tcKFWQ1wAWEHaSw/Q=",
+        "lastModified": 1643616825,
+        "narHash": "sha256-b25RjpLzUgD2nqWfbcAsm+ik9nHYtAM7XO18hHv7gns=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "1e96ff0474cbbae7e72f49739a7b09f48fe25c62",
+        "rev": "19311b9ef8f8f8c71b2f41b59ec9e436646b667c",
         "type": "github"
       },
       "original": {
@@ -168,29 +171,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1643080866,
-        "narHash": "sha256-iO3Z6jw0HEiie8UnXVpq1SxphprDYBXrVzubEa5D4eE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c07b471b52be8fbc49a7dc194e9b37a6e19ee04d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nur": {
       "locked": {
-        "lastModified": 1643209414,
-        "narHash": "sha256-4kqXYhXekbhL1jySPVDw4hk3G42Wg1XU6gZpJ6V0uqk=",
+        "lastModified": 1643638090,
+        "narHash": "sha256-WsKb6tu/53JPasUstCoE4DsJH51DwpbqkAfuEhnSOPI=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "a83e8146667a14183792153152f970d00dd8efd3",
+        "rev": "fa5a03dc64c3123b5723ef16b1097909f42991c4",
         "type": "github"
       },
       "original": {
@@ -206,18 +193,18 @@
         "flake-compat": "flake-compat",
         "home-manager": "home-manager",
         "neovim-nightly": "neovim-nightly",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nur": "nur"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1643126615,
-        "narHash": "sha256-H1CZ9b0GckNeRNxwzuRZUVKmb6TF1q44wfyQlmuQlEY=",
+        "lastModified": 1643580505,
+        "narHash": "sha256-6+d/x7ZIyvkPLdn7ziXuPyKfxt/7z5PCWs7B960DFqk=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "2cb85c14b622002767c66881c6a316a94e0f0be4",
+        "rev": "fd3942eb620e37a4e4bfdd587d8a2893ccf6fea0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/d81537d2ea5cd1e9866f8e58a7b756a4b2a5070c' (2022-01-26)
  → 'github:nix-community/fenix/bd91b6fddf7fdf90ad9924339fcb40f008f57447' (2022-01-31)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-analyzer/rust-analyzer/2cb85c14b622002767c66881c6a316a94e0f0be4' (2022-01-25)
  → 'github:rust-analyzer/rust-analyzer/fd3942eb620e37a4e4bfdd587d8a2893ccf6fea0' (2022-01-30)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/990ca662c4b92636053ea399f5fb80702830522c' (2022-01-25)
  → 'github:nix-community/home-manager/95d39e13a4a7a818c87f2701b59820d3ac0e674c' (2022-01-30)
 - Updated `np`: `neovim-nightly` ➡️ ``
    'github:nix-community/neovim-nightly-overlay/1e96ff0474cbbae7e72f49739a7b09f48fe25c62' (2022-01-26)
  → 'github:nix-community/neovim-nightly-overlay/19311b9ef8f8f8c71b2f41b59ec9e436646b667c' (2022-01-31)
 - Updated `np`: `neovim-nightly/neovim-flake` ➡️ ``
    'github:neovim/neovim/ecec957125ca95ef5fbc4534d62ed16cfedb0c44?dir=contrib' (2022-01-25)
  → 'github:neovim/neovim/2870311a37314135b73e0ee54b41da86c9540a39?dir=contrib' (2022-01-31)
 - Updated `np`: `neovim-nightly/neovim-flake/nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/5bb20f9dc70e9ee16e21cc404b6508654931ce41' (2022-01-28)
  → follows 'neovim-nightly/nixpkgs'
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/c07b471b52be8fbc49a7dc194e9b37a6e19ee04d' (2022-01-25)
  → 'github:nixos/nixpkgs/5bb20f9dc70e9ee16e21cc404b6508654931ce41' (2022-01-28)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/a83e8146667a14183792153152f970d00dd8efd3' (2022-01-26)
  → 'github:nix-community/nur/fa5a03dc64c3123b5723ef16b1097909f42991c4' (2022-01-31)