### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642495030,
-        "narHash": "sha256-u1ZlFbLWzkM6zOfuZ1tr0tzTuDWucOYwALPWDWLorkE=",
+        "lastModified": 1645293039,
+        "narHash": "sha256-PwdDu+SkX8dreeuJ/4av1sEluNZdrpdXv8JsRKKg1Yc=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "bcdb6022b3a300abf59cb5d0106c158940f5120e",
+        "rev": "1df878b6f8351795a3bebfbe4fd2d02e1e8b29d6",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1643869431,
-        "narHash": "sha256-M+khM8s4Kz70q1jCpNX+Cx/YH6cZnn32yCW4udZMCVk=",
+        "lastModified": 1646461454,
+        "narHash": "sha256-3DHmPqxICR8QAjCYbch0Nn2R0yEhpo/HJ95EY4TPqvo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "2d64d0c1941b2b82d938e82790ea0e692889c23b",
+        "rev": "aeac7629f1d069e6f874cd044453a7ed1c2cefd7",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643933104,
-        "narHash": "sha256-NZPuFxRsZKN8pjRuHPpzlMyt6JQhcjiduBG8bMghSjE=",
+        "lastModified": 1646364779,
+        "narHash": "sha256-481vkO9b3h++bHzLbGDDhgpBoXQ0Wlo4lm4h5/EJMO4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "63dccc4e60422c1db2c3929b2fd1541f36b7e664",
+        "rev": "d119cea3763977801ad66330668c1ab4346cb7f7",
         "type": "github"
       },
       "original": {
@@ -112,15 +112,18 @@
     "neovim-flake": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "neovim-nightly",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1643987241,
-        "narHash": "sha256-s94M2ta+BkdVUrrSQQvwz7kenc+GPP7W1vvkwBLD0zk=",
+        "lastModified": 1646409857,
+        "narHash": "sha256-OTAoEd45pdGwxrFI65kdI7uVzcRW/mZ2XO9sI99GRTo=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "dcbf9f93e9038d9b4eb782aff2a07e2560f6e04e",
+        "rev": "83fc914337100d03f2e41a3943ccf0107d893698",
         "type": "github"
       },
       "original": {
@@ -139,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1644048646,
-        "narHash": "sha256-wYTDoEI+ImMZN9oYvoNGQcFTxTDvrrLZKwohRIS+SN4=",
+        "lastModified": 1646468033,
+        "narHash": "sha256-n95L41zd7ZC239yET/mRg5qG40KETRIRrZESCT6Lhso=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "002d0079996c03a318ee6ca389c4df87d3bbec31",
+        "rev": "586229febddecab333c53ae3984a57fcb46a8195",
         "type": "github"
       },
       "original": {
@@ -154,27 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644525281,
-        "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
+        "lastModified": 1646254136,
+        "narHash": "sha256-8nQx02tTzgYO21BP/dy5BCRopE8OwE8Drsw98j+Qoaw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48d63e924a2666baf37f4f14a18f19347fbd54a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1643805626,
-        "narHash": "sha256-AXLDVMG+UaAGsGSpOtQHPIKB+IZ0KSd9WS77aanGzgc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "554d2d8aa25b6e583575459c297ec23750adb6cb",
+        "rev": "3e072546ea98db00c2364b81491b893673267827",
         "type": "github"
       },
       "original": {
@@ -186,11 +173,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1644106607,
-        "narHash": "sha256-FbSqrGWufYEyipvTheEvNeAnfx97Jpm2rtfLqXTMJ+k=",
+        "lastModified": 1646537650,
+        "narHash": "sha256-2gG5msRfqkEjxM7/L4AqjRkgRb4eQxHc9CFcGMMMSsQ=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "4d39fd74fbb3d455bdc7342eb886e409848e0296",
+        "rev": "d6e6023ca4d782ee59c4f728175bab99d7c8997b",
         "type": "github"
       },
       "original": {
@@ -206,18 +193,18 @@
         "flake-compat": "flake-compat",
         "home-manager": "home-manager",
         "neovim-nightly": "neovim-nightly",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nur": "nur"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1643802160,
-        "narHash": "sha256-m3V0VU1M8k0NBYoLaQZFVZaejtfWn2kLLXxZNnHuujk=",
+        "lastModified": 1646436029,
+        "narHash": "sha256-rkyuH7I4opTJWduDp1Mdw7XnhVjcBpsEG75faSh+MQo=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "9cb6e3a190f7781cb7e243837b47e6889d204d52",
+        "rev": "f1f9163b27cf5413f932ffa24c6f4a97497fa0f8",
         "type": "github"
       },
       "original": {

--- a/system/darwin/hosts/theman/home.nix
+++ b/system/darwin/hosts/theman/home.nix
@@ -41,7 +41,10 @@
       };
     };
     dev = {
-      python.enable = true;
+      python = {
+        enable = true;
+        extraPackages = with pkgs.python39Packages; [ pip pylint setuptools ];
+      };
     };
     shell = {
       bash.enable = true;


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/bcdb6022b3a300abf59cb5d0106c158940f5120e' (2022-01-18)
  → 'github:lnl7/nix-darwin/1df878b6f8351795a3bebfbe4fd2d02e1e8b29d6' (2022-02-19)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/2d64d0c1941b2b82d938e82790ea0e692889c23b' (2022-02-03)
  → 'github:nix-community/fenix/aeac7629f1d069e6f874cd044453a7ed1c2cefd7' (2022-03-05)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-analyzer/rust-analyzer/9cb6e3a190f7781cb7e243837b47e6889d204d52' (2022-02-02)
  → 'github:rust-analyzer/rust-analyzer/f1f9163b27cf5413f932ffa24c6f4a97497fa0f8' (2022-03-04)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/63dccc4e60422c1db2c3929b2fd1541f36b7e664' (2022-02-04)
  → 'github:nix-community/home-manager/d119cea3763977801ad66330668c1ab4346cb7f7' (2022-03-04)
 - Updated `np`: `neovim-nightly` ➡️ ``
    'github:nix-community/neovim-nightly-overlay/002d0079996c03a318ee6ca389c4df87d3bbec31' (2022-02-05)
  → 'github:nix-community/neovim-nightly-overlay/586229febddecab333c53ae3984a57fcb46a8195' (2022-03-05)
 - Updated `np`: `neovim-nightly/neovim-flake` ➡️ ``
    'github:neovim/neovim/dcbf9f93e9038d9b4eb782aff2a07e2560f6e04e?dir=contrib' (2022-02-04)
  → 'github:neovim/neovim/83fc914337100d03f2e41a3943ccf0107d893698?dir=contrib' (2022-03-04)
 - Updated `np`: `neovim-nightly/neovim-flake/nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/48d63e924a2666baf37f4f14a18f19347fbd54a2' (2022-02-10)
  → follows 'neovim-nightly/nixpkgs'
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/554d2d8aa25b6e583575459c297ec23750adb6cb' (2022-02-02)
  → 'github:nixos/nixpkgs/3e072546ea98db00c2364b81491b893673267827' (2022-03-02)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/4d39fd74fbb3d455bdc7342eb886e409848e0296' (2022-02-06)
  → 'github:nix-community/nur/d6e6023ca4d782ee59c4f728175bab99d7c8997b' (2022-03-06)