### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647173930,
-        "narHash": "sha256-8oca3Pc68VrCp8HeOtHmzs5g0rdQnPO9beDEEZJ02W0=",
+        "lastModified": 1648278671,
+        "narHash": "sha256-1WrR9ex+rKTjZtODNUZQhkWYUprtfOkjOyo9YWL2NMs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "17fbc68a6110edbff67e55f7450230a697ecb17e",
+        "rev": "4fdbb8168f61d31d3f90bb0d07f48de709c4fe79",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1647671077,
-        "narHash": "sha256-85Blr43zlys+a0rUBAqzQthE4DnUsJ6oxEheKAu88hg=",
+        "lastModified": 1650090339,
+        "narHash": "sha256-N1a8sCsPu2l7NpZxS/0Q+cnkMPBgRmbXafvuEn7QPV8=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8881b72bbf95655ff2a41b8daea599a8b3dd6c92",
+        "rev": "5cbb7720dcbb684fd8375fdd915fb725a6c2178b",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647731541,
-        "narHash": "sha256-WQG5HRq9uylQV0urLuy/RKzoXAaBPhWUrYdEGnRDCxM=",
+        "lastModified": 1650148597,
+        "narHash": "sha256-/1V3grYy4GaqRgPjbBwWUY8mvZK/lfIPkkVtU/870ss=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e96fc6d8f90c96320a9c7e6663b734ab50ec1794",
+        "rev": "8ab155c61f5821ffda723de88b0009769771d4f2",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1647629880,
-        "narHash": "sha256-1+pI09z+Yvur+p/QBg73FI4U0pbAdjYYtxMI2fSA1Gc=",
+        "lastModified": 1650074328,
+        "narHash": "sha256-CzcPEg3uUuyiVNAAw7u30pQBAYuR6a7YVo+7GhQ5BpI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "f2e5f509d995b291e4b9e05a0c059e83490a18e1",
+        "rev": "3f2e9298bdd971a4d2baa298aff7c6f2c2c1ad1a",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647677635,
-        "narHash": "sha256-CyNERVAVyL58OFuj+S7diHzvyAlE99mt22Hv+AgIXek=",
+        "lastModified": 1650096904,
+        "narHash": "sha256-mSnDYhZCnw13vApIApeZMIYvuYnrd+Bal4aWbD3xzOc=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "f812452dc54373d11280daddf2cf12874c860188",
+        "rev": "ae9ee8abdce8256822879916d386550bb55f5b6c",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1647297614,
-        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
+        "lastModified": 1650076401,
+        "narHash": "sha256-QGxadqKWICchuuLIF2QwmHPVaUk+qO33ml5p1wW4IyA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
+        "rev": "75ad56bdc927f3a9f9e05e3c3614c4c1fcd99fcb",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1647749291,
-        "narHash": "sha256-O7C9DlH2YkqdFZIqAUNweUyP00fCMkUMElzgcrvWkxA=",
+        "lastModified": 1650167814,
+        "narHash": "sha256-dDqowkkb05qIULvxwAq3Tc5jZoXCWQW3dBdxYL8Z2kk=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "29a57e5ffc9105cb37d96fffae22c378abab6b43",
+        "rev": "46611c782718da8dcbe5e51dde286928084d5d3b",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1647631852,
-        "narHash": "sha256-2qIPkErDZSVdmAU1S+zCE0fF4luIKe4+xMYfPXl4wec=",
+        "lastModified": 1650054195,
+        "narHash": "sha256-qWls1s4m9XcvXBkHEUyC54u5Bhr0d6e3TwCxf41WzcY=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "85311a862747e4d4857dd49493e1ef7b45de8be3",
+        "rev": "1c22537b3b7012f76952546ef90b18509a056690",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/17fbc68a6110edbff67e55f7450230a697ecb17e' (2022-03-13)
  → 'github:lnl7/nix-darwin/4fdbb8168f61d31d3f90bb0d07f48de709c4fe79' (2022-03-26)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/8881b72bbf95655ff2a41b8daea599a8b3dd6c92' (2022-03-19)
  → 'github:nix-community/fenix/5cbb7720dcbb684fd8375fdd915fb725a6c2178b' (2022-04-16)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-analyzer/rust-analyzer/85311a862747e4d4857dd49493e1ef7b45de8be3' (2022-03-18)
  → 'github:rust-analyzer/rust-analyzer/1c22537b3b7012f76952546ef90b18509a056690' (2022-04-15)
 - Updated `np`: `flake-compat` ➡️ ``
    'github:edolstra/flake-compat/b7547d3eed6f32d06102ead8991ec52ab0a4f1a7' (2022-01-03)
  → 'github:edolstra/flake-compat/64a525ee38886ab9028e6f61790de0832aa3ef03' (2022-03-25)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/e96fc6d8f90c96320a9c7e6663b734ab50ec1794' (2022-03-19)
  → 'github:nix-community/home-manager/8ab155c61f5821ffda723de88b0009769771d4f2' (2022-04-16)
 - Updated `np`: `neovim-nightly` ➡️ ``
    'github:nix-community/neovim-nightly-overlay/f812452dc54373d11280daddf2cf12874c860188' (2022-03-19)
  → 'github:nix-community/neovim-nightly-overlay/ae9ee8abdce8256822879916d386550bb55f5b6c' (2022-04-16)
 - Updated `np`: `neovim-nightly/flake-compat` ➡️ ``
    'github:edolstra/flake-compat/b7547d3eed6f32d06102ead8991ec52ab0a4f1a7' (2022-01-03)
  → 'github:edolstra/flake-compat/64a525ee38886ab9028e6f61790de0832aa3ef03' (2022-03-25)
 - Updated `np`: `neovim-nightly/neovim-flake` ➡️ ``
    'github:neovim/neovim/f2e5f509d995b291e4b9e05a0c059e83490a18e1?dir=contrib' (2022-03-18)
  → 'github:neovim/neovim/3f2e9298bdd971a4d2baa298aff7c6f2c2c1ad1a?dir=contrib' (2022-04-16)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58' (2022-03-14)
  → 'github:nixos/nixpkgs/75ad56bdc927f3a9f9e05e3c3614c4c1fcd99fcb' (2022-04-16)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/29a57e5ffc9105cb37d96fffae22c378abab6b43' (2022-03-20)
  → 'github:nix-community/nur/46611c782718da8dcbe5e51dde286928084d5d3b' (2022-04-17)