### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1650090339,
-        "narHash": "sha256-N1a8sCsPu2l7NpZxS/0Q+cnkMPBgRmbXafvuEn7QPV8=",
+        "lastModified": 1650176756,
+        "narHash": "sha256-hz2HU7eXPV9dbcOkm82M8YFk42AVdqftkkHwo2vNMpM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "5cbb7720dcbb684fd8375fdd915fb725a6c2178b",
+        "rev": "088fff62814e9a92062534ceba92d98114efdd94",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650148597,
-        "narHash": "sha256-/1V3grYy4GaqRgPjbBwWUY8mvZK/lfIPkkVtU/870ss=",
+        "lastModified": 1650234580,
+        "narHash": "sha256-wTmlRedCrDl+XYJom65GMfI3RgA3eZE/w03lD28Txoc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8ab155c61f5821ffda723de88b0009769771d4f2",
+        "rev": "742c6cb3e9d866e095c629162fe5faf519adeb26",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1650074328,
-        "narHash": "sha256-CzcPEg3uUuyiVNAAw7u30pQBAYuR6a7YVo+7GhQ5BpI=",
+        "lastModified": 1650163326,
+        "narHash": "sha256-4EYcQmcVQ/TQJrwN4pJ98Jbk30J+wEMJsE7seeJn9SM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "3f2e9298bdd971a4d2baa298aff7c6f2c2c1ad1a",
+        "rev": "ae325e627484fa0402a3fd8c75508c8c0f82a9c3",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650096904,
-        "narHash": "sha256-mSnDYhZCnw13vApIApeZMIYvuYnrd+Bal4aWbD3xzOc=",
+        "lastModified": 1650183308,
+        "narHash": "sha256-H+W9ZMEi1IeZE79ocGBObIdciPcf6vswjDZd1fGXoHw=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "ae9ee8abdce8256822879916d386550bb55f5b6c",
+        "rev": "76ec0b5c4c471f1f385602a47008ee6839901c46",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650076401,
-        "narHash": "sha256-QGxadqKWICchuuLIF2QwmHPVaUk+qO33ml5p1wW4IyA=",
+        "lastModified": 1650161686,
+        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "75ad56bdc927f3a9f9e05e3c3614c4c1fcd99fcb",
+        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1650167814,
-        "narHash": "sha256-dDqowkkb05qIULvxwAq3Tc5jZoXCWQW3dBdxYL8Z2kk=",
+        "lastModified": 1650253011,
+        "narHash": "sha256-/dXwdyrQJN/Oe0p3M3depg8GpjmrxOCDL1XKvzbU8cA=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "46611c782718da8dcbe5e51dde286928084d5d3b",
+        "rev": "0d61d0e5cc15c1533661d9b2f950a41a9a837b33",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1650054195,
-        "narHash": "sha256-qWls1s4m9XcvXBkHEUyC54u5Bhr0d6e3TwCxf41WzcY=",
+        "lastModified": 1650143587,
+        "narHash": "sha256-/O+N4JAqRZI7fQu9v7UyHpMKAw/mAlsfpCUXVBawWZo=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "1c22537b3b7012f76952546ef90b18509a056690",
+        "rev": "53afd2a707138230dee582fa1d5c3075cab2b6b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/5cbb7720dcbb684fd8375fdd915fb725a6c2178b' (2022-04-16)
  → 'github:nix-community/fenix/088fff62814e9a92062534ceba92d98114efdd94' (2022-04-17)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-analyzer/rust-analyzer/1c22537b3b7012f76952546ef90b18509a056690' (2022-04-15)
  → 'github:rust-analyzer/rust-analyzer/53afd2a707138230dee582fa1d5c3075cab2b6b7' (2022-04-16)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/8ab155c61f5821ffda723de88b0009769771d4f2' (2022-04-16)
  → 'github:nix-community/home-manager/742c6cb3e9d866e095c629162fe5faf519adeb26' (2022-04-17)
 - Updated `np`: `neovim-nightly` ➡️ ``
    'github:nix-community/neovim-nightly-overlay/ae9ee8abdce8256822879916d386550bb55f5b6c' (2022-04-16)
  → 'github:nix-community/neovim-nightly-overlay/76ec0b5c4c471f1f385602a47008ee6839901c46' (2022-04-17)
 - Updated `np`: `neovim-nightly/neovim-flake` ➡️ ``
    'github:neovim/neovim/3f2e9298bdd971a4d2baa298aff7c6f2c2c1ad1a?dir=contrib' (2022-04-16)
  → 'github:neovim/neovim/ae325e627484fa0402a3fd8c75508c8c0f82a9c3?dir=contrib' (2022-04-17)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/75ad56bdc927f3a9f9e05e3c3614c4c1fcd99fcb' (2022-04-16)
  → 'github:nixos/nixpkgs/1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887' (2022-04-17)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/46611c782718da8dcbe5e51dde286928084d5d3b' (2022-04-17)
  → 'github:nix-community/nur/0d61d0e5cc15c1533661d9b2f950a41a9a837b33' (2022-04-18)