### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1650499578,
-        "narHash": "sha256-iJLetvUtr+NweIt3nbY8zO3NR70cyFBVUHYGViWSosI=",
+        "lastModified": 1650672068,
+        "narHash": "sha256-lt++oCZbD3+qrdMlqVBmecckUExg9A1PhLWkImqLgPM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "db851cb105ac9f295a836a39ff73da14a70ae754",
+        "rev": "4e4914ab2e523f100c06fc5fb253f8625cc67232",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650529029,
-        "narHash": "sha256-/BZThOlIN+Q/YgK2jf5k7l37XiHTnqD318sQpRu0/kU=",
+        "lastModified": 1650701691,
+        "narHash": "sha256-JwvkAgRMtdMKQLjoBFcCu7IyAlAJUisPiksLONWGp1A=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "edf6d999c74bf9772afd7c027e0d0a73bf033b4a",
+        "rev": "ee0dc151a425951a0a6d95a7164b7184e6e0766a",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650161686,
-        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
+        "lastModified": 1650701402,
+        "narHash": "sha256-XKfstdtqDg+O+gNBx1yGVKWIhLgfEDg/e2lvJSsp9vU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
+        "rev": "bc41b01dd7a9fdffd32d9b03806798797532a5fe",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1650567711,
-        "narHash": "sha256-OppHPygtSt9Sw1U4nrRx2ONIS+h7YDk1ECr44/kgDmU=",
+        "lastModified": 1650775191,
+        "narHash": "sha256-m92XdImMuRWzOxN1ZTXqFv7eiHkL+tEjvoswJMqW2U0=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "0191ce3e828a018796fb661b02e0e685cab52b73",
+        "rev": "2a211052daea8400fe7f92f5057122ec2eecac61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `neovim-nightly` ➡️ ``
    'github:nix-community/neovim-nightly-overlay/edf6d999c74bf9772afd7c027e0d0a73bf033b4a' (2022-04-21)
  → 'github:nix-community/neovim-nightly-overlay/ee0dc151a425951a0a6d95a7164b7184e6e0766a' (2022-04-23)
 - Updated `np`: `neovim-nightly/neovim-flake` ➡️ ``
    'github:neovim/neovim/db851cb105ac9f295a836a39ff73da14a70ae754?dir=contrib' (2022-04-21)
  → 'github:neovim/neovim/4e4914ab2e523f100c06fc5fb253f8625cc67232?dir=contrib' (2022-04-23)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887' (2022-04-17)
  → 'github:nixos/nixpkgs/bc41b01dd7a9fdffd32d9b03806798797532a5fe' (2022-04-23)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/0191ce3e828a018796fb661b02e0e685cab52b73' (2022-04-21)
  → 'github:nix-community/nur/2a211052daea8400fe7f92f5057122ec2eecac61' (2022-04-24)