### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650399173,
-        "narHash": "sha256-YYJDu6CxLGIrjnH6uAmPxqRmrgrqPhXNZHpZoqw3q5k=",
+        "lastModified": 1650976225,
+        "narHash": "sha256-PGM65SQHS63Dd5MmLJo3GJsZP9lJVZmpWxluQoG1Dt8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "2979028c51ba0ad7e2062dbdc1674be0f71092fc",
+        "rev": "bb3baef6e115ae47bc2ab4973bd3a486488485b0",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1650436102,
-        "narHash": "sha256-phnrZZeTd7jvr2cIDZTDG1ZGo5k3/cEnX15DXIdi1zc=",
+        "lastModified": 1651300005,
+        "narHash": "sha256-Qj5mR4Db0pvuC69tCfuikS97W4B2TZRoMrhxILZGY40=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "6265516f6874bdd6b15904fe8483200cf9a07fe2",
+        "rev": "c043ece6b0a48c384bcdaf7b80851b97d50b13d4",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650478719,
-        "narHash": "sha256-308c2cM4hW9AW6dSQ080ycXGyEJGkG/OwOINkYL9Mnw=",
+        "lastModified": 1651365516,
+        "narHash": "sha256-tN7Eq+uGOGXItR89nEx3X6VJAzf4PvX2u3YnQ1ufb80=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "93a69d07389311ffd6ce1f4d01836bbc2faec644",
+        "rev": "df6010551daa826217939641ab805053f0890239",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1650897858,
-        "narHash": "sha256-SIMA8aB4fGCNKZxTkMzX2EN0uGlDo0sGAJGMbV6lxwY=",
+        "lastModified": 1651381075,
+        "narHash": "sha256-jVU1WolekCTYM6O/8hpVVkpff+sT1EHPHu11ckdx08Q=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "2dddc86a42a77bd099a031165e57add84b9b0e82",
+        "rev": "07660193a38918aa6a17ec691c4e8b021436ed67",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650701402,
-        "narHash": "sha256-XKfstdtqDg+O+gNBx1yGVKWIhLgfEDg/e2lvJSsp9vU=",
+        "lastModified": 1651007983,
+        "narHash": "sha256-GNay7yDPtLcRcKCNHldug85AhAvBpTtPEJWSSDYBw8U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bc41b01dd7a9fdffd32d9b03806798797532a5fe",
+        "rev": "e10da1c7f542515b609f8dfbcf788f3d85b14936",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1650775191,
-        "narHash": "sha256-m92XdImMuRWzOxN1ZTXqFv7eiHkL+tEjvoswJMqW2U0=",
+        "lastModified": 1651378070,
+        "narHash": "sha256-DfvDbQ/6omESOKdmmhM0o7Ij59M8qlYz6qS5AFPymsY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "2a211052daea8400fe7f92f5057122ec2eecac61",
+        "rev": "f40e33bde8437989a08998fd230582168ab537a9",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1650386793,
-        "narHash": "sha256-rGYLQHKfuIgv7ebc+kM72re/K4sOMopWD+iOoa9z2HU=",
+        "lastModified": 1651234072,
+        "narHash": "sha256-i0G0brnVCe82OtWlfLWeMfhDLmtuqN4nOH5HKXLwp8E=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "55824021e10d296a10948549e49a5bdc8dc1c661",
+        "rev": "c6995a372f48afb40e2657defb448312281be8ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/2979028c51ba0ad7e2062dbdc1674be0f71092fc' (2022-04-19)
  → 'github:lnl7/nix-darwin/bb3baef6e115ae47bc2ab4973bd3a486488485b0' (2022-04-26)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/6265516f6874bdd6b15904fe8483200cf9a07fe2' (2022-04-20)
  → 'github:nix-community/fenix/c043ece6b0a48c384bcdaf7b80851b97d50b13d4' (2022-04-30)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-analyzer/rust-analyzer/55824021e10d296a10948549e49a5bdc8dc1c661' (2022-04-19)
  → 'github:rust-analyzer/rust-analyzer/c6995a372f48afb40e2657defb448312281be8ad' (2022-04-29)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/93a69d07389311ffd6ce1f4d01836bbc2faec644' (2022-04-20)
  → 'github:nix-community/home-manager/df6010551daa826217939641ab805053f0890239' (2022-05-01)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/2dddc86a42a77bd099a031165e57add84b9b0e82?dir=contrib' (2022-04-25)
  → 'github:neovim/neovim/07660193a38918aa6a17ec691c4e8b021436ed67?dir=contrib' (2022-05-01)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/bc41b01dd7a9fdffd32d9b03806798797532a5fe' (2022-04-23)
  → 'github:nixos/nixpkgs/e10da1c7f542515b609f8dfbcf788f3d85b14936' (2022-04-26)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/2a211052daea8400fe7f92f5057122ec2eecac61' (2022-04-24)
  → 'github:nix-community/nur/f40e33bde8437989a08998fd230582168ab537a9' (2022-05-01)