### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650976225,
-        "narHash": "sha256-PGM65SQHS63Dd5MmLJo3GJsZP9lJVZmpWxluQoG1Dt8=",
+        "lastModified": 1651916036,
+        "narHash": "sha256-UuD9keUGm4IuVEV6wdSYbuRm7CwfXE63hVkzKDjVsh4=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "bb3baef6e115ae47bc2ab4973bd3a486488485b0",
+        "rev": "2f2bdf658d2b79bada78dc914af99c53cad37cba",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1651300005,
-        "narHash": "sha256-Qj5mR4Db0pvuC69tCfuikS97W4B2TZRoMrhxILZGY40=",
+        "lastModified": 1651904839,
+        "narHash": "sha256-gOtq9g4JknCGfiKKG3Z81ZIpjzA7lHs+77a5eOZsA30=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "c043ece6b0a48c384bcdaf7b80851b97d50b13d4",
+        "rev": "fc75cd2a04c398c7f7f77e44b09776bf74198708",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651365516,
-        "narHash": "sha256-tN7Eq+uGOGXItR89nEx3X6VJAzf4PvX2u3YnQ1ufb80=",
+        "lastModified": 1651886851,
+        "narHash": "sha256-kbXOJSf1uho0/7P54nZkJdJY3oAelIjyc6tfiRhaXJI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "df6010551daa826217939641ab805053f0890239",
+        "rev": "882bd8118bdbff3a6e53e5ced393932b351ce2f6",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1651381075,
-        "narHash": "sha256-jVU1WolekCTYM6O/8hpVVkpff+sT1EHPHu11ckdx08Q=",
+        "lastModified": 1651967472,
+        "narHash": "sha256-IWS9TZM069Vx5zfoome6DQtksrTQH+hYE/6SMbqeiqI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "07660193a38918aa6a17ec691c4e8b021436ed67",
+        "rev": "1b1cc4d864b4b15e705c1a500e64c7bfbacedae7",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651007983,
-        "narHash": "sha256-GNay7yDPtLcRcKCNHldug85AhAvBpTtPEJWSSDYBw8U=",
+        "lastModified": 1651726670,
+        "narHash": "sha256-dSGdzB49SEvdOJvrQWfQYkAefewXraHIV08Vz6iDXWQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e10da1c7f542515b609f8dfbcf788f3d85b14936",
+        "rev": "c777cdf5c564015d5f63b09cc93bef4178b19b01",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651378070,
-        "narHash": "sha256-DfvDbQ/6omESOKdmmhM0o7Ij59M8qlYz6qS5AFPymsY=",
+        "lastModified": 1651978787,
+        "narHash": "sha256-NDoM0VivWmUcCZU2UL80MEZ2I9dj7h0DrxZa316Edq4=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "f40e33bde8437989a08998fd230582168ab537a9",
+        "rev": "9ac6be88c1f75b86545fd96feba56f7d880fe293",
         "type": "github"
       },
       "original": {
@@ -161,15 +161,15 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1651234072,
-        "narHash": "sha256-i0G0brnVCe82OtWlfLWeMfhDLmtuqN4nOH5HKXLwp8E=",
-        "owner": "rust-analyzer",
+        "lastModified": 1651855183,
+        "narHash": "sha256-+TPGrCPENNsWkiyTPhuOqX5fIH0molVHHv42dZyX/jU=",
+        "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "c6995a372f48afb40e2657defb448312281be8ad",
+        "rev": "81b3e6d124db18cd6015b7d763addfd63e0bd54a",
         "type": "github"
       },
       "original": {
-        "owner": "rust-analyzer",
+        "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
         "type": "github"


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/bb3baef6e115ae47bc2ab4973bd3a486488485b0' (2022-04-26)
  → 'github:lnl7/nix-darwin/2f2bdf658d2b79bada78dc914af99c53cad37cba' (2022-05-07)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/c043ece6b0a48c384bcdaf7b80851b97d50b13d4' (2022-04-30)
  → 'github:nix-community/fenix/fc75cd2a04c398c7f7f77e44b09776bf74198708' (2022-05-07)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-analyzer/rust-analyzer/c6995a372f48afb40e2657defb448312281be8ad' (2022-04-29)
  → 'github:rust-lang/rust-analyzer/81b3e6d124db18cd6015b7d763addfd63e0bd54a' (2022-05-06)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/df6010551daa826217939641ab805053f0890239' (2022-05-01)
  → 'github:nix-community/home-manager/882bd8118bdbff3a6e53e5ced393932b351ce2f6' (2022-05-07)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/07660193a38918aa6a17ec691c4e8b021436ed67?dir=contrib' (2022-05-01)
  → 'github:neovim/neovim/1b1cc4d864b4b15e705c1a500e64c7bfbacedae7?dir=contrib' (2022-05-07)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/e10da1c7f542515b609f8dfbcf788f3d85b14936' (2022-04-26)
  → 'github:nixos/nixpkgs/c777cdf5c564015d5f63b09cc93bef4178b19b01' (2022-05-05)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/f40e33bde8437989a08998fd230582168ab537a9' (2022-05-01)
  → 'github:nix-community/nur/9ac6be88c1f75b86545fd96feba56f7d880fe293' (2022-05-08)