### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1651904839,
-        "narHash": "sha256-gOtq9g4JknCGfiKKG3Z81ZIpjzA7lHs+77a5eOZsA30=",
+        "lastModified": 1652510491,
+        "narHash": "sha256-GOKq3B5VK8jYXSZHVY9aDUWyVjoDqlszj7UAuf1IkzI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "fc75cd2a04c398c7f7f77e44b09776bf74198708",
+        "rev": "39cba6b66a005bfb62d46f8b108cf844adb097e9",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651886851,
-        "narHash": "sha256-kbXOJSf1uho0/7P54nZkJdJY3oAelIjyc6tfiRhaXJI=",
+        "lastModified": 1652452043,
+        "narHash": "sha256-nh3mdVB/Kk5ag1uRMAlKo8r+ssN3HNxwbLsqRG4xZkw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "882bd8118bdbff3a6e53e5ced393932b351ce2f6",
+        "rev": "273598f53e04f0111dca5724b37640e3907edaaf",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1651967472,
-        "narHash": "sha256-IWS9TZM069Vx5zfoome6DQtksrTQH+hYE/6SMbqeiqI=",
+        "lastModified": 1652553339,
+        "narHash": "sha256-NEDgBYdc2LRWIwOGG0TPtUsjw+4eDxQWUdoIfKW33gA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "1b1cc4d864b4b15e705c1a500e64c7bfbacedae7",
+        "rev": "0adc66171a355a12494d87ebb767d509540c7ef9",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651726670,
-        "narHash": "sha256-dSGdzB49SEvdOJvrQWfQYkAefewXraHIV08Vz6iDXWQ=",
+        "lastModified": 1652467128,
+        "narHash": "sha256-1wuQ7QgPQ3tugYcoVMJ3pUzl4wVdBzKZr9qtJAgA4VI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c777cdf5c564015d5f63b09cc93bef4178b19b01",
+        "rev": "fb222e008681fce4608e94f2d1dfdf3d03a364c4",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1651978787,
-        "narHash": "sha256-NDoM0VivWmUcCZU2UL80MEZ2I9dj7h0DrxZa316Edq4=",
+        "lastModified": 1652584206,
+        "narHash": "sha256-3ArYXZW8fts+PijLtsii9B7DCmWNY7ehLhzkptGDzQU=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "9ac6be88c1f75b86545fd96feba56f7d880fe293",
+        "rev": "76a09c52fa2747dd54f7d4aa3d157612b48d9f36",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1651855183,
-        "narHash": "sha256-+TPGrCPENNsWkiyTPhuOqX5fIH0molVHHv42dZyX/jU=",
+        "lastModified": 1652470592,
+        "narHash": "sha256-YC+JRw3fRS3qUR+rDKoitVj8fQIkVYtQYjJ0ENEYvEM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "81b3e6d124db18cd6015b7d763addfd63e0bd54a",
+        "rev": "06448c5548d5d15c1dbbb5d89ba951504762a05e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/fc75cd2a04c398c7f7f77e44b09776bf74198708' (2022-05-07)
  → 'github:nix-community/fenix/39cba6b66a005bfb62d46f8b108cf844adb097e9' (2022-05-14)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/81b3e6d124db18cd6015b7d763addfd63e0bd54a' (2022-05-06)
  → 'github:rust-lang/rust-analyzer/06448c5548d5d15c1dbbb5d89ba951504762a05e' (2022-05-13)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/882bd8118bdbff3a6e53e5ced393932b351ce2f6' (2022-05-07)
  → 'github:nix-community/home-manager/273598f53e04f0111dca5724b37640e3907edaaf' (2022-05-13)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/1b1cc4d864b4b15e705c1a500e64c7bfbacedae7?dir=contrib' (2022-05-07)
  → 'github:neovim/neovim/0adc66171a355a12494d87ebb767d509540c7ef9?dir=contrib' (2022-05-14)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/c777cdf5c564015d5f63b09cc93bef4178b19b01' (2022-05-05)
  → 'github:nixos/nixpkgs/fb222e008681fce4608e94f2d1dfdf3d03a364c4' (2022-05-13)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/9ac6be88c1f75b86545fd96feba56f7d880fe293' (2022-05-08)
  → 'github:nix-community/nur/76a09c52fa2747dd54f7d4aa3d157612b48d9f36' (2022-05-15)