### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1652510491,
-        "narHash": "sha256-GOKq3B5VK8jYXSZHVY9aDUWyVjoDqlszj7UAuf1IkzI=",
+        "lastModified": 1653114522,
+        "narHash": "sha256-NxQKYpdaBR6KWXf4U0VFrdgecQwq2r9gg3f7D2Oz5/E=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "39cba6b66a005bfb62d46f8b108cf844adb097e9",
+        "rev": "e3b401ca3ea0b553e2e3db52feb00e0fa8c31996",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1652452043,
-        "narHash": "sha256-nh3mdVB/Kk5ag1uRMAlKo8r+ssN3HNxwbLsqRG4xZkw=",
+        "lastModified": 1653153149,
+        "narHash": "sha256-8B/tWWZziFq4DqnAm9uO7M4Z4PNfllYg5+teX1e5yDQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "273598f53e04f0111dca5724b37640e3907edaaf",
+        "rev": "94780dd888881bf35165dfdd334a57ef6b14ead8",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1652553339,
-        "narHash": "sha256-NEDgBYdc2LRWIwOGG0TPtUsjw+4eDxQWUdoIfKW33gA=",
+        "lastModified": 1653177131,
+        "narHash": "sha256-YfPM6yjKWu4RPAtLefggWC0ZOGgbcPsk6VT5M3D41B0=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "0adc66171a355a12494d87ebb767d509540c7ef9",
+        "rev": "5193b17839c6524bb72ca35cbfc477c4ddd8ef13",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652467128,
-        "narHash": "sha256-1wuQ7QgPQ3tugYcoVMJ3pUzl4wVdBzKZr9qtJAgA4VI=",
+        "lastModified": 1652885393,
+        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fb222e008681fce4608e94f2d1dfdf3d03a364c4",
+        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1652584206,
-        "narHash": "sha256-3ArYXZW8fts+PijLtsii9B7DCmWNY7ehLhzkptGDzQU=",
+        "lastModified": 1653192230,
+        "narHash": "sha256-jqlqpshKyrRpSVKZnf4Klx+mSnflj+hjigNFoDTOuyc=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "76a09c52fa2747dd54f7d4aa3d157612b48d9f36",
+        "rev": "738353fd4b7514f81a1f9e7251eed972a6327ac8",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1652470592,
-        "narHash": "sha256-YC+JRw3fRS3qUR+rDKoitVj8fQIkVYtQYjJ0ENEYvEM=",
+        "lastModified": 1653060552,
+        "narHash": "sha256-b3o/D4GFuy1bCj59Ea1d74rvcEKCzLpAdmMIfJBtRJ0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "06448c5548d5d15c1dbbb5d89ba951504762a05e",
+        "rev": "11823872240d83aa5075575056414cd7d29eba3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/39cba6b66a005bfb62d46f8b108cf844adb097e9' (2022-05-14)
  → 'github:nix-community/fenix/e3b401ca3ea0b553e2e3db52feb00e0fa8c31996' (2022-05-21)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/06448c5548d5d15c1dbbb5d89ba951504762a05e' (2022-05-13)
  → 'github:rust-lang/rust-analyzer/11823872240d83aa5075575056414cd7d29eba3f' (2022-05-20)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/273598f53e04f0111dca5724b37640e3907edaaf' (2022-05-13)
  → 'github:nix-community/home-manager/94780dd888881bf35165dfdd334a57ef6b14ead8' (2022-05-21)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/0adc66171a355a12494d87ebb767d509540c7ef9?dir=contrib' (2022-05-14)
  → 'github:neovim/neovim/5193b17839c6524bb72ca35cbfc477c4ddd8ef13?dir=contrib' (2022-05-21)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/fb222e008681fce4608e94f2d1dfdf3d03a364c4' (2022-05-13)
  → 'github:nixos/nixpkgs/48037fd90426e44e4bf03e6479e88a11453b9b66' (2022-05-18)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/76a09c52fa2747dd54f7d4aa3d157612b48d9f36' (2022-05-15)
  → 'github:nix-community/nur/738353fd4b7514f81a1f9e7251eed972a6327ac8' (2022-05-22)