### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1653114522,
-        "narHash": "sha256-NxQKYpdaBR6KWXf4U0VFrdgecQwq2r9gg3f7D2Oz5/E=",
+        "lastModified": 1653460119,
+        "narHash": "sha256-tP4mnBaE/2yehchIeRrCueF2NLS1G2XKGKq+q/oG0+o=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e3b401ca3ea0b553e2e3db52feb00e0fa8c31996",
+        "rev": "9a49d754de250ad696e49c9ae4ce4561ffe3fc38",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653153149,
-        "narHash": "sha256-8B/tWWZziFq4DqnAm9uO7M4Z4PNfllYg5+teX1e5yDQ=",
+        "lastModified": 1653518057,
+        "narHash": "sha256-cam3Nfae5ADeEs6mRPzr0jXB7+DhyMIXz0/0Q13r/yk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "94780dd888881bf35165dfdd334a57ef6b14ead8",
+        "rev": "64831f938bd413cefde0b0cf871febc494afaa4f",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1653434172,
-        "narHash": "sha256-hCm9+5ehYeWHzU/n3T7QKi5n+k1JuOZeETvKg/YDpic=",
+        "lastModified": 1653782425,
+        "narHash": "sha256-nBdjMFOcxiDpqyD9VYFmtoHxn0/btXhLwuOkTRaGH5s=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "af2899aee0b27e27d658c5f9053b83f439210cea",
+        "rev": "f31a10204c573188e8fb76a10d22f9d4bae907f1",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
+        "lastModified": 1653581809,
+        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
+        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1653192230,
-        "narHash": "sha256-jqlqpshKyrRpSVKZnf4Klx+mSnflj+hjigNFoDTOuyc=",
+        "lastModified": 1653797235,
+        "narHash": "sha256-wcR7uRpRLN0pww9+vJBVv5/UWrwcDL4pynIPIgFbG3w=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "738353fd4b7514f81a1f9e7251eed972a6327ac8",
+        "rev": "99305a5ca98f2fde1460d481df606cde90af5893",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1653060552,
-        "narHash": "sha256-b3o/D4GFuy1bCj59Ea1d74rvcEKCzLpAdmMIfJBtRJ0=",
+        "lastModified": 1653426632,
+        "narHash": "sha256-hDUT+zbzU7SOJJr3VoKiDLJLubu7x6ggDfJ2rzYnYxY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "11823872240d83aa5075575056414cd7d29eba3f",
+        "rev": "d7c147406eff20783abba6ff1fe250ecc44cf800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/e3b401ca3ea0b553e2e3db52feb00e0fa8c31996' (2022-05-21)
  → 'github:nix-community/fenix/9a49d754de250ad696e49c9ae4ce4561ffe3fc38' (2022-05-25)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/11823872240d83aa5075575056414cd7d29eba3f' (2022-05-20)
  → 'github:rust-lang/rust-analyzer/d7c147406eff20783abba6ff1fe250ecc44cf800' (2022-05-24)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/94780dd888881bf35165dfdd334a57ef6b14ead8' (2022-05-21)
  → 'github:nix-community/home-manager/64831f938bd413cefde0b0cf871febc494afaa4f' (2022-05-25)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/af2899aee0b27e27d658c5f9053b83f439210cea?dir=contrib' (2022-05-24)
  → 'github:neovim/neovim/f31a10204c573188e8fb76a10d22f9d4bae907f1?dir=contrib' (2022-05-29)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/48037fd90426e44e4bf03e6479e88a11453b9b66' (2022-05-18)
  → 'github:nixos/nixpkgs/83658b28fe638a170a19b8933aa008b30640fbd1' (2022-05-26)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/738353fd4b7514f81a1f9e7251eed972a6327ac8' (2022-05-22)
  → 'github:nix-community/nur/99305a5ca98f2fde1460d481df606cde90af5893' (2022-05-29)