### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1653114522,
-        "narHash": "sha256-NxQKYpdaBR6KWXf4U0VFrdgecQwq2r9gg3f7D2Oz5/E=",
+        "lastModified": 1655706580,
+        "narHash": "sha256-7DshIT1Ya5W9NAW7UdnYCHsGmXfOXJZCEHbbB/cCX7g=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e3b401ca3ea0b553e2e3db52feb00e0fa8c31996",
+        "rev": "d895003d8e03ac2fc8ffe2aa898299cbef1a7048",
         "type": "github"
       },
       "original": {
@@ -43,6 +43,22 @@
       }
     },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1650374568,
@@ -75,16 +91,20 @@
     },
     "home-manager": {
       "inputs": {
+        "flake-compat": "flake-compat_2",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "nmd": "nmd",
+        "nmt": "nmt",
+        "utils": "utils"
       },
       "locked": {
-        "lastModified": 1653153149,
-        "narHash": "sha256-8B/tWWZziFq4DqnAm9uO7M4Z4PNfllYg5+teX1e5yDQ=",
+        "lastModified": 1655928858,
+        "narHash": "sha256-qVOcb7WVDiqs2yseZwCZRsKT0be8bF3NZufdBZVvZXU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "94780dd888881bf35165dfdd334a57ef6b14ead8",
+        "rev": "e622bad16372aa5ada79a7fa749ec78715dffc54",
         "type": "github"
       },
       "original": {
@@ -102,11 +122,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1653434172,
-        "narHash": "sha256-hCm9+5ehYeWHzU/n3T7QKi5n+k1JuOZeETvKg/YDpic=",
+        "lastModified": 1656032696,
+        "narHash": "sha256-GFGsaJqnmtCdfmB1ptJ9jJJ7Ro2yS2NYYHapGHZZMQM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "af2899aee0b27e27d658c5f9053b83f439210cea",
+        "rev": "3a4fa22badc5595afc0a994ead965ff32ccf6c76",
         "type": "github"
       },
       "original": {
@@ -118,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
+        "lastModified": 1655895887,
+        "narHash": "sha256-AbihSVmPKFcQmaVgzNSLQ8sLAaVTTELPSzZ+/gRVfyk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
+        "rev": "e1e08fe28bf0588a41cd556eac40b98d2793da99",
         "type": "github"
       },
       "original": {
@@ -132,13 +152,45 @@
         "type": "github"
       }
     },
+    "nmd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653339422,
+        "narHash": "sha256-RNLq09vfj21TyYuUCeD6BNTNC6Ew8bLhQULZytN4Xx8=",
+        "owner": "rycee",
+        "repo": "nmd",
+        "rev": "91dee681dd1c478d6040a00835d73c0f4a4c5c29",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmd",
+        "type": "gitlab"
+      }
+    },
+    "nmt": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648075362,
+        "narHash": "sha256-u36WgzoA84dMVsGXzml4wZ5ckGgfnvS0ryzo/3zn/Pc=",
+        "owner": "rycee",
+        "repo": "nmt",
+        "rev": "d83601002c99b78c89ea80e5e6ba21addcfe12ae",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmt",
+        "type": "gitlab"
+      }
+    },
     "nur": {
       "locked": {
-        "lastModified": 1653192230,
-        "narHash": "sha256-jqlqpshKyrRpSVKZnf4Klx+mSnflj+hjigNFoDTOuyc=",
+        "lastModified": 1655986856,
+        "narHash": "sha256-l8n54+zPqzY7P6L5e92WHnosoPfn0u5s9P3Pzq9DGPE=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "738353fd4b7514f81a1f9e7251eed972a6327ac8",
+        "rev": "cca78c92b9b23038a78a07fb9f9070dac477c961",
         "type": "github"
       },
       "original": {
@@ -161,17 +213,32 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1653060552,
-        "narHash": "sha256-b3o/D4GFuy1bCj59Ea1d74rvcEKCzLpAdmMIfJBtRJ0=",
+        "lastModified": 1655654433,
+        "narHash": "sha256-auHQ0XPCiaTPSn+R3Yu4J7oZ5Zq/FS5/Da1ivvdYb/Y=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "11823872240d83aa5075575056414cd7d29eba3f",
+        "rev": "427061da19723f2206fe4dcb175c9c43b9a6193d",
         "type": "github"
       },
       "original": {
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/home/modules/shell/nushell.nix
+++ b/home/modules/shell/nushell.nix
@@ -8,6 +8,10 @@ in
     enable = mkEnableOption "neovim configuration";
   };
   config = mkIf cfg.enable {
-    programs.nushell.enable = true;
+    programs.nushell = {
+      enable = true;
+      configFile.text = "";
+      envFile.text = "";
+    };
   };
 }

--- a/system/darwin/hosts/theman/home.nix
+++ b/system/darwin/hosts/theman/home.nix
@@ -11,7 +11,6 @@
     fd
     sd
     dua
-    procs
   ];
 
   # Manage home-manager with home-manager (inception)


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/e3b401ca3ea0b553e2e3db52feb00e0fa8c31996' (2022-05-21)
  → 'github:nix-community/fenix/d895003d8e03ac2fc8ffe2aa898299cbef1a7048' (2022-06-20)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/11823872240d83aa5075575056414cd7d29eba3f' (2022-05-20)
  → 'github:rust-lang/rust-analyzer/427061da19723f2206fe4dcb175c9c43b9a6193d' (2022-06-19)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/94780dd888881bf35165dfdd334a57ef6b14ead8' (2022-05-21)
  → 'github:nix-community/home-manager/e622bad16372aa5ada79a7fa749ec78715dffc54' (2022-06-22)
• Added input 'home-manager/flake-compat':
    'github:edolstra/flake-compat/b4a34015c698c7793d592d66adbab377907a2be8' (2022-04-19)
• Added input 'home-manager/nmd':
    'gitlab:rycee/nmd/91dee681dd1c478d6040a00835d73c0f4a4c5c29' (2022-05-23)
• Added input 'home-manager/nmt':
    'gitlab:rycee/nmt/d83601002c99b78c89ea80e5e6ba21addcfe12ae' (2022-03-23)
• Added input 'home-manager/utils':
    'github:numtide/flake-utils/1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1' (2022-05-30)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/af2899aee0b27e27d658c5f9053b83f439210cea?dir=contrib' (2022-05-24)
  → 'github:neovim/neovim/3a4fa22badc5595afc0a994ead965ff32ccf6c76?dir=contrib' (2022-06-24)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/48037fd90426e44e4bf03e6479e88a11453b9b66' (2022-05-18)
  → 'github:nixos/nixpkgs/e1e08fe28bf0588a41cd556eac40b98d2793da99' (2022-06-22)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/738353fd4b7514f81a1f9e7251eed972a6327ac8' (2022-05-22)
  → 'github:nix-community/nur/cca78c92b9b23038a78a07fb9f9070dac477c961' (2022-06-23)