### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1655706580,
-        "narHash": "sha256-7DshIT1Ya5W9NAW7UdnYCHsGmXfOXJZCEHbbB/cCX7g=",
+        "lastModified": 1656138322,
+        "narHash": "sha256-ZHh/3So9OvOH/A+axJowVcjDmPmQ/aZAFbhvfWYln/I=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d895003d8e03ac2fc8ffe2aa898299cbef1a7048",
+        "rev": "2f1c9a040c790f9ed13ae933b748a55578138777",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1655928858,
-        "narHash": "sha256-qVOcb7WVDiqs2yseZwCZRsKT0be8bF3NZufdBZVvZXU=",
+        "lastModified": 1656199469,
+        "narHash": "sha256-17t4qc016C1p6oNSKOrYbOCErWhQI4dr4nzJKrGO8VE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e622bad16372aa5ada79a7fa749ec78715dffc54",
+        "rev": "1dbac84b846e4bfa21a08e31e95e11f0965ed042",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1656032696,
-        "narHash": "sha256-GFGsaJqnmtCdfmB1ptJ9jJJ7Ro2yS2NYYHapGHZZMQM=",
+        "lastModified": 1656192687,
+        "narHash": "sha256-3vc/3adq8fAa1kNDLM8kvUeON96iqtU6ClQ6V3fKWg4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "3a4fa22badc5595afc0a994ead965ff32ccf6c76",
+        "rev": "7dd73625dccc8abddf892b54017b655cdafa1183",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655895887,
-        "narHash": "sha256-AbihSVmPKFcQmaVgzNSLQ8sLAaVTTELPSzZ+/gRVfyk=",
+        "lastModified": 1655983783,
+        "narHash": "sha256-0h1FzkYWei24IdKNpCX93onkF/FMiXQG8SdEbTc0r8A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e1e08fe28bf0588a41cd556eac40b98d2793da99",
+        "rev": "6141b8932a5cf376fe18fcd368cecd9ad946cb68",
         "type": "github"
       },
       "original": {
@@ -186,11 +186,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1655986856,
-        "narHash": "sha256-l8n54+zPqzY7P6L5e92WHnosoPfn0u5s9P3Pzq9DGPE=",
+        "lastModified": 1656220390,
+        "narHash": "sha256-+44i2ECanpFxKPGTaeBbtfUqOrsdejq9iJTMPyJUj5w=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "cca78c92b9b23038a78a07fb9f9070dac477c961",
+        "rev": "4554fbdd624190cffbf4e50f2f3664489a518fa4",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1655654433,
-        "narHash": "sha256-auHQ0XPCiaTPSn+R3Yu4J7oZ5Zq/FS5/Da1ivvdYb/Y=",
+        "lastModified": 1656092520,
+        "narHash": "sha256-HLb4ql9GDuXf/lF5wH6jdlL7E6MARmthGvHOgrpsSl8=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "427061da19723f2206fe4dcb175c9c43b9a6193d",
+        "rev": "5bb123d97000a85c7a909fe1ab0b981d54c967f2",
         "type": "github"
       },
       "original": {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -76,30 +76,34 @@ rec {
     in
     nameValuePair name (
       inputs.home-manager.lib.homeManagerConfiguration {
-        inherit pkgs system username homeDirectory;
-        configuration = { ... }: {
-          imports =
-            let
-              userConf = strToFile config ../home/hosts;
-              home = mkUserHome { inherit system; config = userConf; };
-            in
-            [ home ];
+        inherit pkgs;
+        modules = [
+          {
+            home = { inherit username homeDirectory; };
 
-          xdg.configFile."nix/nix.conf".text =
-            let
-              nixConf = import ../nix/conf.nix;
-            in
-            ''
-              extra-substituters = ${builtins.concatStringsSep " " nixConf.binaryCaches }
-              extra-trusted-public-keys = ${builtins.concatStringsSep " " nixConf.binaryCachePublicKeys}
-              experimental-features = nix-command flakes
-            '';
+            imports =
+              let
+                userConf = strToFile config ../home/hosts;
+                home = mkUserHome { inherit system; config = userConf; };
+              in
+              [ home ];
 
-          nixpkgs = {
-            config = import ../nix/config.nix;
-            overlays = inputs.self.overlays."${system}";
-          };
-        };
+            xdg.configFile."nix/nix.conf".text =
+              let
+                nixConf = import ../nix/conf.nix;
+              in
+              ''
+                extra-substituters = ${builtins.concatStringsSep " " nixConf.binaryCaches }
+                extra-trusted-public-keys = ${builtins.concatStringsSep " " nixConf.binaryCachePublicKeys}
+                experimental-features = nix-command flakes
+              '';
+
+            nixpkgs = {
+              config = import ../nix/config.nix;
+              overlays = inputs.self.overlays."${system}";
+            };
+          }
+        ];
         extraSpecialArgs =
           let
             self = inputs.self;


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/d895003d8e03ac2fc8ffe2aa898299cbef1a7048' (2022-06-20)
  → 'github:nix-community/fenix/2f1c9a040c790f9ed13ae933b748a55578138777' (2022-06-25)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/427061da19723f2206fe4dcb175c9c43b9a6193d' (2022-06-19)
  → 'github:rust-lang/rust-analyzer/5bb123d97000a85c7a909fe1ab0b981d54c967f2' (2022-06-24)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/e622bad16372aa5ada79a7fa749ec78715dffc54' (2022-06-22)
  → 'github:nix-community/home-manager/1dbac84b846e4bfa21a08e31e95e11f0965ed042' (2022-06-25)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/3a4fa22badc5595afc0a994ead965ff32ccf6c76?dir=contrib' (2022-06-24)
  → 'github:neovim/neovim/7dd73625dccc8abddf892b54017b655cdafa1183?dir=contrib' (2022-06-25)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/e1e08fe28bf0588a41cd556eac40b98d2793da99' (2022-06-22)
  → 'github:nixos/nixpkgs/6141b8932a5cf376fe18fcd368cecd9ad946cb68' (2022-06-23)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/cca78c92b9b23038a78a07fb9f9070dac477c961' (2022-06-23)
  → 'github:nix-community/nur/4554fbdd624190cffbf4e50f2f3664489a518fa4' (2022-06-26)