### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651916036,
-        "narHash": "sha256-UuD9keUGm4IuVEV6wdSYbuRm7CwfXE63hVkzKDjVsh4=",
+        "lastModified": 1657835815,
+        "narHash": "sha256-CnZszAYpNKydh6N7+xg+eRtWNVoAAGqc6bg+Lpgq1xc=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "2f2bdf658d2b79bada78dc914af99c53cad37cba",
+        "rev": "54a24f042f93c79f5679f133faddedec61955cf2",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1657347958,
-        "narHash": "sha256-UViOt1l9Qu1StbAIDe+xMjRbkEnefbISbs256J5IcHE=",
+        "lastModified": 1657952734,
+        "narHash": "sha256-xmDbPkC783R+03Dvi+KlZmo8BS2kcX9pKc7pwlqMbno=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d223a6c360d0873488b70df0a9d27e0f6487b8fe",
+        "rev": "6d837959635996aa3751ebc83f666d71144e459b",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1657396086,
-        "narHash": "sha256-4cQ6hEuewWoFkTBlu211JGxPQQ1Zyli8oEq1cu7cVeA=",
+        "lastModified": 1657887110,
+        "narHash": "sha256-8VV0/kZed2z8fGtEc2zr+WLxTow+JTIlMjnSisyv0GQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c645cc9f82c7753450d1fa4d1bc73b64960a9d7a",
+        "rev": "4c5106ed0f3168ff2df21b646aef67e86cbfc11c",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1657427803,
-        "narHash": "sha256-9PmEoXdLmIYrFdOLQxiDwJv2+cYJf8rXtSS6hTRGGIo=",
+        "lastModified": 1658028632,
+        "narHash": "sha256-ZsYfaAzeWAyLJXC8Xg8Gkfq12wqeoAJkWRNPjgq3A98=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "8f36e538cc6178b66f27d9096e4f4da7fadafa7a",
+        "rev": "53c398d8f44f1796c216402c953512eb57733529",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657265485,
-        "narHash": "sha256-PUQ9C7mfi0/BnaAUX2R/PIkoNCb/Jtx9EpnhMBNrO/o=",
+        "lastModified": 1657802959,
+        "narHash": "sha256-9+JWARSdlL8KiH3ymnKDXltE1vM+/WEJ78F5B1kjXys=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b39924fc7764c08ae3b51beef9a3518c414cdb7d",
+        "rev": "4a01ca36d6bfc133bc617e661916a81327c9bbc8",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1657426050,
-        "narHash": "sha256-h0DdHX7Dp8E+vQz+C/Ozq4ddNwT+Su76Py39hos8vus=",
+        "lastModified": 1658031703,
+        "narHash": "sha256-boHqVQ+viWDl+DsQKGIYrzk1APnltySr2+KITCwKJ+E=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "a3361ad2a54bdc9f63ab79cf19c4bb512e67f65d",
+        "rev": "bb65b1c6020ea9d565dc4d192b3b7752d0cb8232",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1657292522,
-        "narHash": "sha256-mAxbvJzcpozcQpcfNAP1eU27NgAqT6pDB/eaQOe/piI=",
+        "lastModified": 1657832242,
+        "narHash": "sha256-zqMCj+ra4dx/Z+9HaKPalKMSUfhLZIvud6ocKae45Tk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "2836dd15f753a490ea5b89e02c6cfcecd2f32984",
+        "rev": "029184d9772c9d0ad749400409be1a3feb473521",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/2f2bdf658d2b79bada78dc914af99c53cad37cba' (2022-05-07)
  → 'github:lnl7/nix-darwin/54a24f042f93c79f5679f133faddedec61955cf2' (2022-07-14)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/d223a6c360d0873488b70df0a9d27e0f6487b8fe' (2022-07-09)
  → 'github:nix-community/fenix/6d837959635996aa3751ebc83f666d71144e459b' (2022-07-16)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/2836dd15f753a490ea5b89e02c6cfcecd2f32984' (2022-07-08)
  → 'github:rust-lang/rust-analyzer/029184d9772c9d0ad749400409be1a3feb473521' (2022-07-14)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/c645cc9f82c7753450d1fa4d1bc73b64960a9d7a' (2022-07-09)
  → 'github:nix-community/home-manager/4c5106ed0f3168ff2df21b646aef67e86cbfc11c' (2022-07-15)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/8f36e538cc6178b66f27d9096e4f4da7fadafa7a?dir=contrib' (2022-07-10)
  → 'github:neovim/neovim/53c398d8f44f1796c216402c953512eb57733529?dir=contrib' (2022-07-17)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/b39924fc7764c08ae3b51beef9a3518c414cdb7d' (2022-07-08)
  → 'github:nixos/nixpkgs/4a01ca36d6bfc133bc617e661916a81327c9bbc8' (2022-07-14)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/a3361ad2a54bdc9f63ab79cf19c4bb512e67f65d' (2022-07-10)
  → 'github:nix-community/nur/bb65b1c6020ea9d565dc4d192b3b7752d0cb8232' (2022-07-17)