### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1659162347,
-        "narHash": "sha256-nN93gaGPGep8meP2/zGv7fL7KOcmyfj1/PWDHX4UJMU=",
+        "lastModified": 1659767175,
+        "narHash": "sha256-xNWIjrdpqTDhGpgiC/CO9WXRatSDTG1j+NGuLn2Uq+U=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "4fc95f732d7a8c97d8307854532e29a96238779c",
+        "rev": "5878e50188643a549a9f451d8724ae6d16147a74",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1659232160,
-        "narHash": "sha256-RYKbKAYooiART2RUEpUnP7tAYM6+2i1m9+QI14wljZU=",
+        "lastModified": 1659484873,
+        "narHash": "sha256-6VoPiGyDdjBHOJ3IpS24lY1lrDiOHeuEefOFI0qz3WE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7146638e9ef74aba6736cbbf12dbe60e1ed24c1e",
+        "rev": "d8d9ff0b2df77defa10375c6665b51f0251c34d6",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1659244399,
-        "narHash": "sha256-6AlHM5YGKjIoYPeZq06/KSNnKGcfKIt7O3bTrWtFbFc=",
+        "lastModified": 1659790417,
+        "narHash": "sha256-xYu81/AjIWWIjv7BrhJgRfTPTjKfHGOanM+1jRcg0Lo=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "c1652bdcb5b5ca95b5ae328cec582f23816b70dd",
+        "rev": "0fdf59ac9d30d8874ba6eba22a8bdfb41c1603b7",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659131907,
-        "narHash": "sha256-8bz4k18M/FuVC+EVcI4aREN2PsEKT7LGmU2orfjnpCg=",
+        "lastModified": 1659713809,
+        "narHash": "sha256-M4aHuXXVnfprM8xPH2lLkYkkR0fmaG5QmvIc0DT/d4E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8d435fca5c561da8168abb30270788d2da2a7951",
+        "rev": "93c57a988470c1948976b1bb70abbd5855c5b810",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1659242433,
-        "narHash": "sha256-xJrLhY+aRXAFl6766Z2ExnM+vAiX2W++95oYfPCet8Y=",
+        "lastModified": 1659846509,
+        "narHash": "sha256-eI47vTor0dGWdeNXP0g0TctWcCcZopUifJHqvfQtXUg=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "de7a939aaf7a78198b0bc2e84a747780ed6f7f6c",
+        "rev": "58ee99eaf9204abed58caa95f66f53bcc00498d0",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1659238192,
-        "narHash": "sha256-MWFE9H81sMeBYw0CeBPvBwACKDVSi7Uq5DulL+Xp5h8=",
+        "lastModified": 1659816186,
+        "narHash": "sha256-lJPGbnceEyWQVRtfDg8KcSKcDysApzHgMBDs+L2/eHA=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "dd2a0e35f48e36e0648e29438a0b1df13644c2b7",
+        "rev": "a96fc21f88507464a450767a62acaba03aa6b8e8",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1659109296,
-        "narHash": "sha256-p4SkyEOXk480q7Ue8DrEKNw6lUkp2BhTp8DNsXk+ml4=",
+        "lastModified": 1659705224,
+        "narHash": "sha256-We0FUZQIag2UbdqKJuc1aNj46d0KLJ3tepa3N2QEMko=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "fb5e49631bac0584348c052e939bd3fcf1cc967c",
+        "rev": "3792720086faccb3ee085558ad082c979785f437",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/4fc95f732d7a8c97d8307854532e29a96238779c' (2022-07-30)
  → 'github:nix-community/fenix/5878e50188643a549a9f451d8724ae6d16147a74' (2022-08-06)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/fb5e49631bac0584348c052e939bd3fcf1cc967c' (2022-07-29)
  → 'github:rust-lang/rust-analyzer/3792720086faccb3ee085558ad082c979785f437' (2022-08-05)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/7146638e9ef74aba6736cbbf12dbe60e1ed24c1e' (2022-07-31)
  → 'github:nix-community/home-manager/d8d9ff0b2df77defa10375c6665b51f0251c34d6' (2022-08-03)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/c1652bdcb5b5ca95b5ae328cec582f23816b70dd?dir=contrib' (2022-07-31)
  → 'github:neovim/neovim/0fdf59ac9d30d8874ba6eba22a8bdfb41c1603b7?dir=contrib' (2022-08-06)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/8d435fca5c561da8168abb30270788d2da2a7951' (2022-07-29)
  → 'github:nixos/nixpkgs/93c57a988470c1948976b1bb70abbd5855c5b810' (2022-08-05)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/de7a939aaf7a78198b0bc2e84a747780ed6f7f6c' (2022-07-31)
  → 'github:nix-community/nur/58ee99eaf9204abed58caa95f66f53bcc00498d0' (2022-08-07)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/dd2a0e35f48e36e0648e29438a0b1df13644c2b7' (2022-07-31)
  → 'github:nushell/nushell/a96fc21f88507464a450767a62acaba03aa6b8e8' (2022-08-06)