### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657835815,
-        "narHash": "sha256-CnZszAYpNKydh6N7+xg+eRtWNVoAAGqc6bg+Lpgq1xc=",
+        "lastModified": 1660649317,
+        "narHash": "sha256-16sWaj3cTZOQQgrmzlvBSRaBFKLrHJrfYh1k7/sSWok=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "54a24f042f93c79f5679f133faddedec61955cf2",
+        "rev": "80871c71edb3da76d40bdff9cae007a2a035c074",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1660371988,
-        "narHash": "sha256-3acMu6H1R00Q27E7hie/a8jHIIbxFuRuk1RoZIDu7sw=",
+        "lastModified": 1660890677,
+        "narHash": "sha256-Pjo7boTFANtflin0ESiwhFIrtCfss0z2DjEbKMjeFh8=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "ccd2c48e886d325ff0130781db69394c6906a245",
+        "rev": "dca822b67ddf0af52f9b63feaeefc1668c8635c0",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1660330190,
-        "narHash": "sha256-RgQUtZGmdb9fRkdBcI8x1KYuykbQCBaeY6ejFls7hFM=",
+        "lastModified": 1660574517,
+        "narHash": "sha256-Lp5D2pAPrM3iAc1eeR0iGwz5rM+SYOWzVxI3p17nlrU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8675cfa549e1240c9d2abb1c878bc427eefcf926",
+        "rev": "688e5c85b7537f308b82167c8eb4ecfb70a49861",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1660430311,
-        "narHash": "sha256-LK24LTg1ORq8xR0AKHUNlnCBZh2FQxjdVViNk4P97J0=",
+        "lastModified": 1661053033,
+        "narHash": "sha256-tUoH/Sy52Ri4qI05WHvH+9/rQN9jihneXUFeZUmLPZs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "5854103dad5a9ae513c089a514364eff55582fbb",
+        "rev": "6b9852cc4188d9ca7bce8e7592dcfca38539c743",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660305968,
-        "narHash": "sha256-r0X1pZCSEA6mzt5OuTA7nHuLmvnbkwgpFAh1iLIx4GU=",
+        "lastModified": 1660908602,
+        "narHash": "sha256-SwZ85IPWvC4NxxFhWhRMTJpApSHbY1u4YK2UFWEBWvY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c4a0efdd5a728e20791b8d8d2f26f90ac228ee8d",
+        "rev": "495b19d5b3e62b4ec7e846bdfb6ef3d9c3b83492",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1660451864,
-        "narHash": "sha256-AxmIbRoLZrhd7xLAIK+vCHc2yyqPXMg1GLyB/CqZowo=",
+        "lastModified": 1661056622,
+        "narHash": "sha256-CHnAsASJb/0u3jeNxzgFwIYWKyW1FEhUX+mEl2Cg1zU=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "69df06f35c435ce77fa61845ed8e7ba96fa56091",
+        "rev": "b0ebe831dd4add1ce7444f7ad94c55fdf8a215d9",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1660417680,
-        "narHash": "sha256-5tnKtjEF8QeYnuRwp90rmlTBmuWHJzNFAp04MyG/+dE=",
+        "lastModified": 1661047470,
+        "narHash": "sha256-xg+u3Ynr4BgjGr+gYdqiWiUdb6eLxpY3ePthxGsqgS8=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "eb55fd238307f5c91e181131289afd987d6031d6",
+        "rev": "37bc90c62a75c906edfe5f7373a68850b9c9124c",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1660317798,
-        "narHash": "sha256-p04X8tlCsUZyeenQZXBioxOXbmGqehI2VwV58ywIg6k=",
+        "lastModified": 1660838778,
+        "narHash": "sha256-SpV0kKZ5b0+w6y15x7ZvBTjxOiAfqgyPq5SWpHDxoV4=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "f982c7616196b433bd65a1df1d07ee0d249701c0",
+        "rev": "917bd68b37de4e60e7203061a0a9c23b74d2b5c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/54a24f042f93c79f5679f133faddedec61955cf2' (2022-07-14)
  → 'github:lnl7/nix-darwin/80871c71edb3da76d40bdff9cae007a2a035c074' (2022-08-16)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/ccd2c48e886d325ff0130781db69394c6906a245' (2022-08-13)
  → 'github:nix-community/fenix/dca822b67ddf0af52f9b63feaeefc1668c8635c0' (2022-08-19)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/f982c7616196b433bd65a1df1d07ee0d249701c0' (2022-08-12)
  → 'github:rust-lang/rust-analyzer/917bd68b37de4e60e7203061a0a9c23b74d2b5c2' (2022-08-18)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/8675cfa549e1240c9d2abb1c878bc427eefcf926' (2022-08-12)
  → 'github:nix-community/home-manager/688e5c85b7537f308b82167c8eb4ecfb70a49861' (2022-08-15)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/5854103dad5a9ae513c089a514364eff55582fbb?dir=contrib' (2022-08-13)
  → 'github:neovim/neovim/6b9852cc4188d9ca7bce8e7592dcfca38539c743?dir=contrib' (2022-08-21)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/c4a0efdd5a728e20791b8d8d2f26f90ac228ee8d' (2022-08-12)
  → 'github:nixos/nixpkgs/495b19d5b3e62b4ec7e846bdfb6ef3d9c3b83492' (2022-08-19)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/69df06f35c435ce77fa61845ed8e7ba96fa56091' (2022-08-14)
  → 'github:nix-community/nur/b0ebe831dd4add1ce7444f7ad94c55fdf8a215d9' (2022-08-21)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/eb55fd238307f5c91e181131289afd987d6031d6' (2022-08-13)
  → 'github:nushell/nushell/37bc90c62a75c906edfe5f7373a68850b9c9124c' (2022-08-21)