### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660649317,
-        "narHash": "sha256-16sWaj3cTZOQQgrmzlvBSRaBFKLrHJrfYh1k7/sSWok=",
+        "lastModified": 1665392861,
+        "narHash": "sha256-bCd8fYJMAb0LzabsiXl4nxECDoz483bJOCa2hjox7N0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "80871c71edb3da76d40bdff9cae007a2a035c074",
+        "rev": "ef56fd8979b5f4e800c4716f62076e00600b1172",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1660890677,
-        "narHash": "sha256-Pjo7boTFANtflin0ESiwhFIrtCfss0z2DjEbKMjeFh8=",
+        "lastModified": 1665902130,
+        "narHash": "sha256-XJ9gVyx5N2RiiBhn0BFyAcLf6/tKzjljCZlRD1QwMuk=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "dca822b67ddf0af52f9b63feaeefc1668c8635c0",
+        "rev": "e48ce691b34fd5e6cec35489f482484ae64711fa",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1660574517,
-        "narHash": "sha256-Lp5D2pAPrM3iAc1eeR0iGwz5rM+SYOWzVxI3p17nlrU=",
+        "lastModified": 1665949912,
+        "narHash": "sha256-NAp+YHTxgnpEaIJanOmtUx9XAnhKTCzG8LlFyZIAz7M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "688e5c85b7537f308b82167c8eb4ecfb70a49861",
+        "rev": "04f53999788cd47c6ce932d6cbd7cbfd3998712f",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1661053033,
-        "narHash": "sha256-tUoH/Sy52Ri4qI05WHvH+9/rQN9jihneXUFeZUmLPZs=",
+        "lastModified": 1665959511,
+        "narHash": "sha256-i1GTocOEwoJtnqzChI2t4BVF3YlOMvyUkpfwYpeD4zk=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "6b9852cc4188d9ca7bce8e7592dcfca38539c743",
+        "rev": "8617101b6bf21bf27ba5194db5fb42c73ff67160",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660908602,
-        "narHash": "sha256-SwZ85IPWvC4NxxFhWhRMTJpApSHbY1u4YK2UFWEBWvY=",
+        "lastModified": 1665848363,
+        "narHash": "sha256-3Jow1YxzPtQnck1bAAvbVxgRH4gNnkIdw871Vm6UtAU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "495b19d5b3e62b4ec7e846bdfb6ef3d9c3b83492",
+        "rev": "83b198a2083774844962c854f811538323f9f7b1",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1661056622,
-        "narHash": "sha256-CHnAsASJb/0u3jeNxzgFwIYWKyW1FEhUX+mEl2Cg1zU=",
+        "lastModified": 1665979830,
+        "narHash": "sha256-0xcqP+Pr2zeX8A2BpqodcPwN5sR0TfC8twuXUjzG2g4=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "b0ebe831dd4add1ce7444f7ad94c55fdf8a215d9",
+        "rev": "704e1ef5bdb1af57b4f7988abf2ef80c897dfc9b",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1661047470,
-        "narHash": "sha256-xg+u3Ynr4BgjGr+gYdqiWiUdb6eLxpY3ePthxGsqgS8=",
+        "lastModified": 1665957075,
+        "narHash": "sha256-ZBB++EXb3ZcatV6f7UHrsFp8HXWFQI73NVqK4XFH6G0=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "37bc90c62a75c906edfe5f7373a68850b9c9124c",
+        "rev": "803f9d4daff434ef5e4c6535d9d3f9fc70bd2de1",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1660838778,
-        "narHash": "sha256-SpV0kKZ5b0+w6y15x7ZvBTjxOiAfqgyPq5SWpHDxoV4=",
+        "lastModified": 1665834494,
+        "narHash": "sha256-s1rlphWs4n27o6mnt+WE7vobl52tWfe/uPHVyR7FuC0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "917bd68b37de4e60e7203061a0a9c23b74d2b5c2",
+        "rev": "5174d3d030c3f38e7f3fea857cc8a0f59f24b219",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {

--- a/home/hosts/eden.nix
+++ b/home/hosts/eden.nix
@@ -16,12 +16,12 @@
             key = ../../config/.gnupg/public.key;
           }];
         };
-        repo = let r = import ../common/repo.nix; in
-          {
-            enable = true;
-            projects = r.projects;
-            tags = r.tags;
-          };
+        # repo = let r = import ../common/repo.nix; in
+        #   {
+        #     enable = true;
+        #     projects = r.projects;
+        #     tags = r.tags;
+        #   };
       };
     };
     profiles = {

--- a/home/profiles/common.nix
+++ b/home/profiles/common.nix
@@ -32,7 +32,7 @@ in
         # Man pages
         man
         man-pages
-        posix_man_pages
+        man-pages-posix
         stdman
         # grep alternative.
         ripgrep

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -141,7 +141,7 @@ rec {
             { pkgs, ... }: {
               # Don't rely on the configuration to enable a flake-compatible version of Nix.
               nix = {
-                package = pkgs.nixFlakes;
+                package = pkgs.nixVersions.stable;
                 extraOptions = "experimental-features = nix-command flakes";
               };
             }
@@ -210,7 +210,7 @@ rec {
               # Don't rely on the configuration to enable a flake-compatible version of Nix.
               nix = {
                 inherit (nixConf) binaryCaches binaryCachePublicKeys;
-                package = pkgs.nixFlakes;
+                package = pkgs.nixVersions.stable;
                 extraOptions = "experimental-features = nix-command flakes";
               };
               services.nix-daemon.enable = true;

--- a/shell.nix
+++ b/shell.nix
@@ -17,7 +17,7 @@ pkgs.mkShell {
 
   shellHook = ''
       PATH=${pkgs.writeShellScriptBin "nix" ''
-      ${pkgs.nixFlakes}/bin/nix ${builtins.concatStringsSep " " options} "$@"
+      ${pkgs.nixVersions.stable}/bin/nix ${builtins.concatStringsSep " " options} "$@"
     ''}/bin:$PATH
   '';
 }

--- a/system/darwin/hosts/theman/home.nix
+++ b/system/darwin/hosts/theman/home.nix
@@ -64,12 +64,6 @@
           key = ../../../../config/.gnupg/public.key;
         }];
       };
-
-      repo = {
-        enable = true;
-        cli = true;
-        root = "${config.home.homeDirectory}/dev";
-      };
     };
   };
 }

--- a/system/nixos/hosts/pride/home.nix
+++ b/system/nixos/hosts/pride/home.nix
@@ -25,12 +25,12 @@
             key = ../../../../config/.gnupg/public.key;
           }];
         };
-        repo = let r = import ../../../../home/common/repo.nix; in
-          {
-            enable = true;
-            projects = r.projects;
-            tags = r.tags;
-          };
+        # repo = let r = import ../../../../home/common/repo.nix; in
+        #   {
+        #     enable = true;
+        #     projects = r.projects;
+        #     tags = r.tags;
+        #   };
       };
     };
 


### PR DESCRIPTION
Flake lock file changes:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/80871c71edb3da76d40bdff9cae007a2a035c074' (2022-08-16)
  → 'github:lnl7/nix-darwin/ef56fd8979b5f4e800c4716f62076e00600b1172' (2022-10-10)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/dca822b67ddf0af52f9b63feaeefc1668c8635c0' (2022-08-19)
  → 'github:nix-community/fenix/e48ce691b34fd5e6cec35489f482484ae64711fa' (2022-10-16)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/917bd68b37de4e60e7203061a0a9c23b74d2b5c2' (2022-08-18)
  → 'github:rust-lang/rust-analyzer/5174d3d030c3f38e7f3fea857cc8a0f59f24b219' (2022-10-15)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/688e5c85b7537f308b82167c8eb4ecfb70a49861' (2022-08-15)
  → 'github:nix-community/home-manager/04f53999788cd47c6ce932d6cbd7cbfd3998712f' (2022-10-16)
 - Updated `np`: `home-manager/utils` ➡️ ``
    'github:numtide/flake-utils/1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1' (2022-05-30)
  → 'github:numtide/flake-utils/c0e246b9b83f637f4681389ecabcb2681b4f3af0' (2022-08-07)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/6b9852cc4188d9ca7bce8e7592dcfca38539c743?dir=contrib' (2022-08-21)
  → 'github:neovim/neovim/8617101b6bf21bf27ba5194db5fb42c73ff67160?dir=contrib' (2022-10-16)
 - Updated `np`: `neovim-flake/flake-utils` ➡️ ``
    'github:numtide/flake-utils/3cecb5b042f7f209c56ffd8371b2711a290ec797' (2022-02-07)
  → 'github:numtide/flake-utils/c0e246b9b83f637f4681389ecabcb2681b4f3af0' (2022-08-07)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/495b19d5b3e62b4ec7e846bdfb6ef3d9c3b83492' (2022-08-19)
  → 'github:nixos/nixpkgs/83b198a2083774844962c854f811538323f9f7b1' (2022-10-15)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/b0ebe831dd4add1ce7444f7ad94c55fdf8a215d9' (2022-08-21)
  → 'github:nix-community/nur/704e1ef5bdb1af57b4f7988abf2ef80c897dfc9b' (2022-10-17)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/37bc90c62a75c906edfe5f7373a68850b9c9124c' (2022-08-21)
  → 'github:nushell/nushell/803f9d4daff434ef5e4c6535d9d3f9fc70bd2de1' (2022-10-16)