### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665392861,
-        "narHash": "sha256-bCd8fYJMAb0LzabsiXl4nxECDoz483bJOCa2hjox7N0=",
+        "lastModified": 1671891118,
+        "narHash": "sha256-+GJYiT7QbfA306ex4sGMlFB8Ts297pn3OdQ9kTd4aDw=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "ef56fd8979b5f4e800c4716f62076e00600b1172",
+        "rev": "267040e7a2b8644f1fdfcf57b7e808c286dbdc7b",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1665902130,
-        "narHash": "sha256-XJ9gVyx5N2RiiBhn0BFyAcLf6/tKzjljCZlRD1QwMuk=",
+        "lastModified": 1671862898,
+        "narHash": "sha256-uWExxLc7cHo1gBmVET/N157mtj8JPgy0cY8mZ8qBJEc=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e48ce691b34fd5e6cec35489f482484ae64711fa",
+        "rev": "df5825b50b784ea13753f08802ff12860afcfc99",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1665949912,
-        "narHash": "sha256-NAp+YHTxgnpEaIJanOmtUx9XAnhKTCzG8LlFyZIAz7M=",
+        "lastModified": 1671831633,
+        "narHash": "sha256-tANQOkJnlqK4M83KvvXFMFrIbR0xkloqXY5ruqzR3kE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04f53999788cd47c6ce932d6cbd7cbfd3998712f",
+        "rev": "d7eee202e597bc7789498a8664082cf0ffedaa8f",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1665959511,
-        "narHash": "sha256-i1GTocOEwoJtnqzChI2t4BVF3YlOMvyUkpfwYpeD4zk=",
+        "lastModified": 1671944850,
+        "narHash": "sha256-zggpqf9UJKdbdWrdD2UmngJBUQ7s6Eim0EJwU/NIYjw=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "8617101b6bf21bf27ba5194db5fb42c73ff67160",
+        "rev": "6f25623e793e058c78481b7fb7a42eeff642694b",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665848363,
-        "narHash": "sha256-3Jow1YxzPtQnck1bAAvbVxgRH4gNnkIdw871Vm6UtAU=",
+        "lastModified": 1671722432,
+        "narHash": "sha256-ojcZUekIQeOZkHHzR81st7qxX99dB1Eaaq6PU5MNeKc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83b198a2083774844962c854f811538323f9f7b1",
+        "rev": "652e92b8064949a11bc193b90b74cb727f2a1405",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665979830,
-        "narHash": "sha256-0xcqP+Pr2zeX8A2BpqodcPwN5sR0TfC8twuXUjzG2g4=",
+        "lastModified": 1671943579,
+        "narHash": "sha256-s0vIzgj9E1jXM5TeQIvVCyHMWJA2z6OXh4xc39xQWv0=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "704e1ef5bdb1af57b4f7988abf2ef80c897dfc9b",
+        "rev": "f02576d604862bc59db6642d874b532fac7ec319",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1665957075,
-        "narHash": "sha256-ZBB++EXb3ZcatV6f7UHrsFp8HXWFQI73NVqK4XFH6G0=",
+        "lastModified": 1671928304,
+        "narHash": "sha256-RR63reVe9n5Bf87iKLtcndMZVv5cIXUY3tQ6skSrD7E=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "803f9d4daff434ef5e4c6535d9d3f9fc70bd2de1",
+        "rev": "24153816829a64b7bc427b248cfbbd0688430ae3",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1665834494,
-        "narHash": "sha256-s1rlphWs4n27o6mnt+WE7vobl52tWfe/uPHVyR7FuC0=",
+        "lastModified": 1671798464,
+        "narHash": "sha256-UtpVOf6c6RVAImQMU1rSO4m7vJtTI7ewwOgM/xYbHDM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "5174d3d030c3f38e7f3fea857cc8a0f59f24b219",
+        "rev": "fb0db2a4202165cf501a755f4d12210043ffb90a",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/ef56fd8979b5f4e800c4716f62076e00600b1172' (2022-10-10)
  → 'github:lnl7/nix-darwin/267040e7a2b8644f1fdfcf57b7e808c286dbdc7b' (2022-12-24)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/e48ce691b34fd5e6cec35489f482484ae64711fa' (2022-10-16)
  → 'github:nix-community/fenix/df5825b50b784ea13753f08802ff12860afcfc99' (2022-12-24)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/5174d3d030c3f38e7f3fea857cc8a0f59f24b219' (2022-10-15)
  → 'github:rust-lang/rust-analyzer/fb0db2a4202165cf501a755f4d12210043ffb90a' (2022-12-23)
 - Updated `np`: `flake-compat` ➡️ ``
    'github:edolstra/flake-compat/b4a34015c698c7793d592d66adbab377907a2be8' (2022-04-19)
  → 'github:edolstra/flake-compat/009399224d5e398d03b22badca40a37ac85412a1' (2022-11-17)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/04f53999788cd47c6ce932d6cbd7cbfd3998712f' (2022-10-16)
  → 'github:nix-community/home-manager/d7eee202e597bc7789498a8664082cf0ffedaa8f' (2022-12-23)
 - Updated `np`: `home-manager/utils` ➡️ ``
    'github:numtide/flake-utils/c0e246b9b83f637f4681389ecabcb2681b4f3af0' (2022-08-07)
  → 'github:numtide/flake-utils/5aed5285a952e0b949eb3ba02c12fa4fcfef535f' (2022-11-02)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/8617101b6bf21bf27ba5194db5fb42c73ff67160?dir=contrib' (2022-10-16)
  → 'github:neovim/neovim/6f25623e793e058c78481b7fb7a42eeff642694b?dir=contrib' (2022-12-25)
 - Updated `np`: `neovim-flake/flake-utils` ➡️ ``
    'github:numtide/flake-utils/c0e246b9b83f637f4681389ecabcb2681b4f3af0' (2022-08-07)
  → 'github:numtide/flake-utils/5aed5285a952e0b949eb3ba02c12fa4fcfef535f' (2022-11-02)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/83b198a2083774844962c854f811538323f9f7b1' (2022-10-15)
  → 'github:nixos/nixpkgs/652e92b8064949a11bc193b90b74cb727f2a1405' (2022-12-22)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/704e1ef5bdb1af57b4f7988abf2ef80c897dfc9b' (2022-10-17)
  → 'github:nix-community/nur/f02576d604862bc59db6642d874b532fac7ec319' (2022-12-25)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/803f9d4daff434ef5e4c6535d9d3f9fc70bd2de1' (2022-10-16)
  → 'github:nushell/nushell/24153816829a64b7bc427b248cfbbd0688430ae3' (2022-12-25)