### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nix
         uses: cachix/install-nix-action@v18

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,70 +43,67 @@ jobs:
           build-mount-path: "/nix"
           overprovision-lvm: "true"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Install nix
-        uses: cachix/install-nix-action@v16
+        uses: cachix/install-nix-action@v18
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.5.1/install
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: edeneast
           skipPush: true
           extraPullNames: nix-community
 
-      - name: Build pr target
-        env:
-          TARGET: ".#top.${{ matrix.target }}"
+      - name: Garbage collect build dependencies
+        run: nix-collect-garbage
+
+      - name: Fetch old system profile
+        run: nix build github:EdenEast/nyx#top.${{ matrix.target }} -v --log-format raw --profile ./profile
+
+      - name: Add new system to profile
         run: |
           set -o pipefail
-          nix build $TARGET --show-trace --fallback -v --log-format raw > >(tee stdout.log) 2> >(tee /tmp/nix-build-err.log >&2)
+          nix build .#top.${{ matrix.target }} --profile ./profile --show-trace --fallback -v --log-format raw > >(tee stdout.log) 2> >(tee /tmp/nix-build-err.log >&2)
 
       - name: Output build failure
         if: failure()
         run: |
           drv=$(grep "For full logs, run" /tmp/nix-build-err.log | grep -oE "/nix/store/.*.drv")
-          nix log $drv
-          echo $drv
+          if [ -n $drv ]; then
+            nix log $drv
+            echo $drv
+          fi
           exit 1
-
-      - name: Fetch current main and build it in a profile
-        env:
-          TARGET: "github:EdenEast/nyx#top.${{ matrix.target }}"
-        run: nix build $TARGET -v --log-format raw --profile ./profile --show-trace --no-write-lock-file
-
-      - name: Apply pr to profile
-        env:
-          TARGET: ".#top.${{ matrix.target }}"
-        run: nix build $TARGET -v --log-format raw --profile ./profile
 
       - name: Diff profile
         id: diff
-        run: |
-          diff="$(nix profile diff-closures --profile ./profile)"
-          echo "$diff"
-          diff="$(echo "$diff" | sed 's/\x1b\[[0-9;]*m//g')"
-          diff="${diff//'%'/'%25'}"
-          diff="${diff//$'\n'/'%0A'}"
-          diff="${diff//$'\r'/'%0D'}"
-          echo "::set-output name=diff::$diff"
+        run: | # https://stackoverflow.com/a/74232400
+          nix profile diff-closures --profile ./profile
+          delimiter="$(openssl rand -hex 16)"
+          echo "diff<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          nix profile diff-closures --profile ./profile | perl -pe 's/\e\[[0-9;]*m(?:\e\[K)?//g' >> "${GITHUB_OUTPUT}"
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - name: Scan for security issues
         id: security
-        run: |
+        run: | # https://stackoverflow.com/a/74232400
           nix run nixpkgs/nixos-unstable#vulnix -- -w https://raw.githubusercontent.com/ckauhaus/nixos-vulnerability-roundup/master/whitelists/nixos-unstable.toml ./profile | tee /tmp/security.txt
           OUTPUT_SECURITY="$(cat /tmp/security.txt)"
           OUTPUT_SECURITY="${OUTPUT_SECURITY//'%'/'%25'}"
           OUTPUT_SECURITY="${OUTPUT_SECURITY//$'\n'/'%0A'}"
           OUTPUT_SECURITY="${OUTPUT_SECURITY//$'\r'/'%0D'}"
           echo "$OUTPUT_SECURITY"
-          echo "::set-output name=security::$OUTPUT_SECURITY"
+
+          delimiter="$(openssl rand -hex 16)"
+          echo "diff<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "$OUTPUT_SECURITY" >> "${GITHUB_OUTPUT}"
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - name: Comment report in pr
         uses: marocchino/sticky-pull-request-comment@v2
@@ -114,18 +111,15 @@ jobs:
           header: ".#top.${{ matrix.target }}"
           message: |
             ### Report for `${{ matrix.target }}`
-            Version changes:
-            ```
-            ${{ steps.diff.outputs.diff }}
-            ```
+
             <details>
-            <summary>
-            Security vulnerability report
-            </summary>
-            <br>
-            <pre>
-            ${{ steps.security.outputs.security }}
-            </pre>
+            <summary> Version changes </summary> <br>
+            <pre> ${{ steps.diff.outputs.diff }} </pre>
+            </details>
+
+            <details>
+            <summary> Security vulnerability report </summary> <br>
+            <pre> ${{ steps.security.outputs.security }} </pre>
             </details>
 
 # Idea reference

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,7 +12,7 @@ jobs:
   flake-update:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665392861,
-        "narHash": "sha256-bCd8fYJMAb0LzabsiXl4nxECDoz483bJOCa2hjox7N0=",
+        "lastModified": 1671891118,
+        "narHash": "sha256-+GJYiT7QbfA306ex4sGMlFB8Ts297pn3OdQ9kTd4aDw=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "ef56fd8979b5f4e800c4716f62076e00600b1172",
+        "rev": "267040e7a2b8644f1fdfcf57b7e808c286dbdc7b",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1665902130,
-        "narHash": "sha256-XJ9gVyx5N2RiiBhn0BFyAcLf6/tKzjljCZlRD1QwMuk=",
+        "lastModified": 1672208605,
+        "narHash": "sha256-RkgnZ/pmInsjepD/rXsjMjJATAXt6npVlE3bJt+Fq0Q=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e48ce691b34fd5e6cec35489f482484ae64711fa",
+        "rev": "8310190b73709f0200fdca818f570623330be716",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1665949912,
-        "narHash": "sha256-NAp+YHTxgnpEaIJanOmtUx9XAnhKTCzG8LlFyZIAz7M=",
+        "lastModified": 1672274925,
+        "narHash": "sha256-DpkuoGwEW92zj/3jWKLb1biF4whs9yIc+pQbg67gqGU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04f53999788cd47c6ce932d6cbd7cbfd3998712f",
+        "rev": "a993eac1065c6ce63a8d724b7bccf624d0e91ca2",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1665959511,
-        "narHash": "sha256-i1GTocOEwoJtnqzChI2t4BVF3YlOMvyUkpfwYpeD4zk=",
+        "lastModified": 1672271726,
+        "narHash": "sha256-fTC/nUc3dihIfZ22wvkoETS5DAxiNLexeIOuV8QVYT8=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "8617101b6bf21bf27ba5194db5fb42c73ff67160",
+        "rev": "05b6dd6e5f543083ebca581506398a8c263a2db6",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665848363,
-        "narHash": "sha256-3Jow1YxzPtQnck1bAAvbVxgRH4gNnkIdw871Vm6UtAU=",
+        "lastModified": 1672080458,
+        "narHash": "sha256-Ukjn8YUwZevxDPaVUmTx2sf9bCcIJSasmLz+xjGBKrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83b198a2083774844962c854f811538323f9f7b1",
+        "rev": "1eb875e811dd59e21e77f6337f2c1592889b48b3",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1665979830,
-        "narHash": "sha256-0xcqP+Pr2zeX8A2BpqodcPwN5sR0TfC8twuXUjzG2g4=",
+        "lastModified": 1672279487,
+        "narHash": "sha256-f5eAV1r7XOitLS+FLpXzTF1+HcEoTK4D8SCkju37NkI=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "704e1ef5bdb1af57b4f7988abf2ef80c897dfc9b",
+        "rev": "6d1298a6defe38e59d5e190148f2080ea947d780",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1665957075,
-        "narHash": "sha256-ZBB++EXb3ZcatV6f7UHrsFp8HXWFQI73NVqK4XFH6G0=",
+        "lastModified": 1672182044,
+        "narHash": "sha256-H7rzJBO5/LHL+naA2BTRTnxzP+LVixcPMtiAJpGlEps=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "803f9d4daff434ef5e4c6535d9d3f9fc70bd2de1",
+        "rev": "f5d6672ccf2aada4f06efc8e9cbfe3a9c7d30f5e",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1665834494,
-        "narHash": "sha256-s1rlphWs4n27o6mnt+WE7vobl52tWfe/uPHVyR7FuC0=",
+        "lastModified": 1672170363,
+        "narHash": "sha256-L2GkQGoKzYzmfa4OouCieT0zl2gxymsf/e/lnLoCQQU=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "5174d3d030c3f38e7f3fea857cc8a0f59f24b219",
+        "rev": "3033c3ddbfcb0e42084ada8931e88d11eb98dee4",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/ef56fd8979b5f4e800c4716f62076e00600b1172' (2022-10-10)
  → 'github:lnl7/nix-darwin/267040e7a2b8644f1fdfcf57b7e808c286dbdc7b' (2022-12-24)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/e48ce691b34fd5e6cec35489f482484ae64711fa' (2022-10-16)
  → 'github:nix-community/fenix/8310190b73709f0200fdca818f570623330be716' (2022-12-28)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/5174d3d030c3f38e7f3fea857cc8a0f59f24b219' (2022-10-15)
  → 'github:rust-lang/rust-analyzer/3033c3ddbfcb0e42084ada8931e88d11eb98dee4' (2022-12-27)
 - Updated `np`: `flake-compat` ➡️ ``
    'github:edolstra/flake-compat/b4a34015c698c7793d592d66adbab377907a2be8' (2022-04-19)
  → 'github:edolstra/flake-compat/009399224d5e398d03b22badca40a37ac85412a1' (2022-11-17)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/04f53999788cd47c6ce932d6cbd7cbfd3998712f' (2022-10-16)
  → 'github:nix-community/home-manager/a993eac1065c6ce63a8d724b7bccf624d0e91ca2' (2022-12-29)
 - Updated `np`: `home-manager/utils` ➡️ ``
    'github:numtide/flake-utils/c0e246b9b83f637f4681389ecabcb2681b4f3af0' (2022-08-07)
  → 'github:numtide/flake-utils/5aed5285a952e0b949eb3ba02c12fa4fcfef535f' (2022-11-02)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/8617101b6bf21bf27ba5194db5fb42c73ff67160?dir=contrib' (2022-10-16)
  → 'github:neovim/neovim/05b6dd6e5f543083ebca581506398a8c263a2db6?dir=contrib' (2022-12-28)
 - Updated `np`: `neovim-flake/flake-utils` ➡️ ``
    'github:numtide/flake-utils/c0e246b9b83f637f4681389ecabcb2681b4f3af0' (2022-08-07)
  → 'github:numtide/flake-utils/5aed5285a952e0b949eb3ba02c12fa4fcfef535f' (2022-11-02)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/83b198a2083774844962c854f811538323f9f7b1' (2022-10-15)
  → 'github:nixos/nixpkgs/1eb875e811dd59e21e77f6337f2c1592889b48b3' (2022-12-26)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/704e1ef5bdb1af57b4f7988abf2ef80c897dfc9b' (2022-10-17)
  → 'github:nix-community/nur/6d1298a6defe38e59d5e190148f2080ea947d780' (2022-12-29)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/803f9d4daff434ef5e4c6535d9d3f9fc70bd2de1' (2022-10-16)
  → 'github:nushell/nushell/f5d6672ccf2aada4f06efc8e9cbfe3a9c7d30f5e' (2022-12-27)