### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1672208605,
-        "narHash": "sha256-RkgnZ/pmInsjepD/rXsjMjJATAXt6npVlE3bJt+Fq0Q=",
+        "lastModified": 1672468395,
+        "narHash": "sha256-eIrQGHZub98IiLqtFXa00ooHBCjtKY+rfKJs5lhyF/c=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8310190b73709f0200fdca818f570623330be716",
+        "rev": "d6f9bdfb4a25395b15f6c6feba3d0bba5e62b3ce",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1672274925,
-        "narHash": "sha256-DpkuoGwEW92zj/3jWKLb1biF4whs9yIc+pQbg67gqGU=",
+        "lastModified": 1672349765,
+        "narHash": "sha256-Ul3lSGglgHXhgU3YNqsNeTlRH1pqxbR64h+2hM+HtnM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a993eac1065c6ce63a8d724b7bccf624d0e91ca2",
+        "rev": "dd99675ee81fef051809bc87d67eb07f5ba022e8",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1672271726,
-        "narHash": "sha256-fTC/nUc3dihIfZ22wvkoETS5DAxiNLexeIOuV8QVYT8=",
+        "lastModified": 1672499781,
+        "narHash": "sha256-YFUj+w0f6bjMI9TJI0rQOuXepzhQzngbXxYbQ0+NTLA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "05b6dd6e5f543083ebca581506398a8c263a2db6",
+        "rev": "6ba34e21fee2a81677e8261dfeaf24c8cd320500",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672080458,
-        "narHash": "sha256-Ukjn8YUwZevxDPaVUmTx2sf9bCcIJSasmLz+xjGBKrs=",
+        "lastModified": 1672350804,
+        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1eb875e811dd59e21e77f6337f2c1592889b48b3",
+        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672279487,
-        "narHash": "sha256-f5eAV1r7XOitLS+FLpXzTF1+HcEoTK4D8SCkju37NkI=",
+        "lastModified": 1672548141,
+        "narHash": "sha256-XSawbt/wy2OG480cZTwmQ/SOcs5IRVYh6ScouwfliNg=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "6d1298a6defe38e59d5e190148f2080ea947d780",
+        "rev": "03b39de5cf7569eab4492e895a4473983bf3a917",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1672182044,
-        "narHash": "sha256-H7rzJBO5/LHL+naA2BTRTnxzP+LVixcPMtiAJpGlEps=",
+        "lastModified": 1672533154,
+        "narHash": "sha256-e5w0wkxIjG+YJQfHywOcyMKFfTdMhWTe9I6gN01e8OE=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "f5d6672ccf2aada4f06efc8e9cbfe3a9c7d30f5e",
+        "rev": "e56c01d0e22149db08ef28efcaaef27839852970",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1672170363,
-        "narHash": "sha256-L2GkQGoKzYzmfa4OouCieT0zl2gxymsf/e/lnLoCQQU=",
+        "lastModified": 1672438471,
+        "narHash": "sha256-bB/7XFnRgGhOhYY6HIov7eF/qnR5NPtKtSfDa2aWqh8=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "3033c3ddbfcb0e42084ada8931e88d11eb98dee4",
+        "rev": "0d76b94c90a20c20d3e57ea1ab03d9afa00dee72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/8310190b73709f0200fdca818f570623330be716' (2022-12-28)
  → 'github:nix-community/fenix/d6f9bdfb4a25395b15f6c6feba3d0bba5e62b3ce' (2022-12-31)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/3033c3ddbfcb0e42084ada8931e88d11eb98dee4' (2022-12-27)
  → 'github:rust-lang/rust-analyzer/0d76b94c90a20c20d3e57ea1ab03d9afa00dee72' (2022-12-30)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/a993eac1065c6ce63a8d724b7bccf624d0e91ca2' (2022-12-29)
  → 'github:nix-community/home-manager/dd99675ee81fef051809bc87d67eb07f5ba022e8' (2022-12-29)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/05b6dd6e5f543083ebca581506398a8c263a2db6?dir=contrib' (2022-12-28)
  → 'github:neovim/neovim/6ba34e21fee2a81677e8261dfeaf24c8cd320500?dir=contrib' (2022-12-31)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/1eb875e811dd59e21e77f6337f2c1592889b48b3' (2022-12-26)
  → 'github:nixos/nixpkgs/677ed08a50931e38382dbef01cba08a8f7eac8f6' (2022-12-29)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/6d1298a6defe38e59d5e190148f2080ea947d780' (2022-12-29)
  → 'github:nix-community/nur/03b39de5cf7569eab4492e895a4473983bf3a917' (2023-01-01)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/f5d6672ccf2aada4f06efc8e9cbfe3a9c7d30f5e' (2022-12-27)
  → 'github:nushell/nushell/e56c01d0e22149db08ef28efcaaef27839852970' (2023-01-01)