### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671891118,
-        "narHash": "sha256-+GJYiT7QbfA306ex4sGMlFB8Ts297pn3OdQ9kTd4aDw=",
+        "lastModified": 1673295039,
+        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "267040e7a2b8644f1fdfcf57b7e808c286dbdc7b",
+        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1672468395,
-        "narHash": "sha256-eIrQGHZub98IiLqtFXa00ooHBCjtKY+rfKJs5lhyF/c=",
+        "lastModified": 1673677311,
+        "narHash": "sha256-V7vEMy7vzvD9wyz/822G8rLV+3jkum5EsfAIy9gds1I=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d6f9bdfb4a25395b15f6c6feba3d0bba5e62b3ce",
+        "rev": "39e4f1d72376620d76fefe4cdf52a448f12c90aa",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1672349765,
-        "narHash": "sha256-Ul3lSGglgHXhgU3YNqsNeTlRH1pqxbR64h+2hM+HtnM=",
+        "lastModified": 1673737886,
+        "narHash": "sha256-hNTqD0uIgpbtTI2Nuj/Q1lEFOOdZqqXpxoc8rMno2F0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dd99675ee81fef051809bc87d67eb07f5ba022e8",
+        "rev": "2827b5306462d91edec16a3d069b2d6e54c3079f",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1672499781,
-        "narHash": "sha256-YFUj+w0f6bjMI9TJI0rQOuXepzhQzngbXxYbQ0+NTLA=",
+        "lastModified": 1673746461,
+        "narHash": "sha256-Y21pbVNlPWPokXFbngSahnxeCff0LX+LKdDktEBIVm4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "6ba34e21fee2a81677e8261dfeaf24c8cd320500",
+        "rev": "6134c1e8a39a5e61d0593613343a5923a86e3545",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672350804,
-        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "lastModified": 1673631141,
+        "narHash": "sha256-AprpYQ5JvLS4wQG/ghm2UriZ9QZXvAwh1HlgA/6ZEVQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "rev": "befc83905c965adfd33e5cae49acb0351f6e0404",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672548141,
-        "narHash": "sha256-XSawbt/wy2OG480cZTwmQ/SOcs5IRVYh6ScouwfliNg=",
+        "lastModified": 1673755893,
+        "narHash": "sha256-5sD9At2yWkIEMz4Haqz8E3GnbxIYOY2uU7Ot8ukXlhQ=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "03b39de5cf7569eab4492e895a4473983bf3a917",
+        "rev": "99bc34da9d3ca463ee6f7a91bc1e853e6b2a3051",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1672533154,
-        "narHash": "sha256-e5w0wkxIjG+YJQfHywOcyMKFfTdMhWTe9I6gN01e8OE=",
+        "lastModified": 1673748212,
+        "narHash": "sha256-KSQa5QbYalNJEn3F3MrsPA3RDRs+PKxWxgxsVf2pCYA=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "e56c01d0e22149db08ef28efcaaef27839852970",
+        "rev": "7221eb7f3971ee2a6fa339c16bb0931571eead14",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1672438471,
-        "narHash": "sha256-bB/7XFnRgGhOhYY6HIov7eF/qnR5NPtKtSfDa2aWqh8=",
+        "lastModified": 1673611648,
+        "narHash": "sha256-Qptnat6M6twwJiXSMt0cJlZdZreExeyzY7cdCG0LicM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "0d76b94c90a20c20d3e57ea1ab03d9afa00dee72",
+        "rev": "a119352adab65d0cab25c13ae0fd7676bed7100f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/267040e7a2b8644f1fdfcf57b7e808c286dbdc7b' (2022-12-24)
  → 'github:lnl7/nix-darwin/87b9d090ad39b25b2400029c64825fc2a8868943' (2023-01-09)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/d6f9bdfb4a25395b15f6c6feba3d0bba5e62b3ce' (2022-12-31)
  → 'github:nix-community/fenix/39e4f1d72376620d76fefe4cdf52a448f12c90aa' (2023-01-14)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/0d76b94c90a20c20d3e57ea1ab03d9afa00dee72' (2022-12-30)
  → 'github:rust-lang/rust-analyzer/a119352adab65d0cab25c13ae0fd7676bed7100f' (2023-01-13)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/dd99675ee81fef051809bc87d67eb07f5ba022e8' (2022-12-29)
  → 'github:nix-community/home-manager/2827b5306462d91edec16a3d069b2d6e54c3079f' (2023-01-14)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/6ba34e21fee2a81677e8261dfeaf24c8cd320500?dir=contrib' (2022-12-31)
  → 'github:neovim/neovim/6134c1e8a39a5e61d0593613343a5923a86e3545?dir=contrib' (2023-01-15)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/677ed08a50931e38382dbef01cba08a8f7eac8f6' (2022-12-29)
  → 'github:nixos/nixpkgs/befc83905c965adfd33e5cae49acb0351f6e0404' (2023-01-13)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/03b39de5cf7569eab4492e895a4473983bf3a917' (2023-01-01)
  → 'github:nix-community/nur/99bc34da9d3ca463ee6f7a91bc1e853e6b2a3051' (2023-01-15)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/e56c01d0e22149db08ef28efcaaef27839852970' (2023-01-01)
  → 'github:nushell/nushell/7221eb7f3971ee2a6fa339c16bb0931571eead14' (2023-01-15)