### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671891118,
-        "narHash": "sha256-+GJYiT7QbfA306ex4sGMlFB8Ts297pn3OdQ9kTd4aDw=",
+        "lastModified": 1673295039,
+        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "267040e7a2b8644f1fdfcf57b7e808c286dbdc7b",
+        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1672468395,
-        "narHash": "sha256-eIrQGHZub98IiLqtFXa00ooHBCjtKY+rfKJs5lhyF/c=",
+        "lastModified": 1673936585,
+        "narHash": "sha256-5fDrM+jPUvXIFnw/72zk/05wfNTXItiG1WhF+1dok1w=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d6f9bdfb4a25395b15f6c6feba3d0bba5e62b3ce",
+        "rev": "a9a262cbec1f1c3f771071fd1a246ee05811f5a1",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1672349765,
-        "narHash": "sha256-Ul3lSGglgHXhgU3YNqsNeTlRH1pqxbR64h+2hM+HtnM=",
+        "lastModified": 1673948101,
+        "narHash": "sha256-cD0OzFfnLFeeaz4jVszH9QiMTn+PBxmcYzrp+xujpwM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dd99675ee81fef051809bc87d67eb07f5ba022e8",
+        "rev": "bd3efacb82c721edad1ce9eda583df5fb62ab00a",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1672499781,
-        "narHash": "sha256-YFUj+w0f6bjMI9TJI0rQOuXepzhQzngbXxYbQ0+NTLA=",
+        "lastModified": 1674014440,
+        "narHash": "sha256-mtnizpeeEQd8R0P3PzsEUhvsJLyOZArFfd561+XFGtk=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "6ba34e21fee2a81677e8261dfeaf24c8cd320500",
+        "rev": "0aae7f386042593aecfc8237020899d0e94fe8e4",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672350804,
-        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "lastModified": 1673796341,
+        "narHash": "sha256-1kZi9OkukpNmOaPY7S5/+SlCDOuYnP3HkXHvNDyLQcc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "rev": "6dccdc458512abce8d19f74195bb20fdb067df50",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1672548141,
-        "narHash": "sha256-XSawbt/wy2OG480cZTwmQ/SOcs5IRVYh6ScouwfliNg=",
+        "lastModified": 1674021312,
+        "narHash": "sha256-kW00Hpb2jqX7zDHnw/us7DH4lChTa6DoVcZZrd9CKwE=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "03b39de5cf7569eab4492e895a4473983bf3a917",
+        "rev": "993b34d7fc525534c59229312c1ff21a976def54",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1672533154,
-        "narHash": "sha256-e5w0wkxIjG+YJQfHywOcyMKFfTdMhWTe9I6gN01e8OE=",
+        "lastModified": 1674006655,
+        "narHash": "sha256-ZY2B7zcu0eg5cpKD+14faCkO2hiRfCYpJekrXtJmho4=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "e56c01d0e22149db08ef28efcaaef27839852970",
+        "rev": "be32aeee70a6d004abbab3e2db229d6246f0f0fd",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1672438471,
-        "narHash": "sha256-bB/7XFnRgGhOhYY6HIov7eF/qnR5NPtKtSfDa2aWqh8=",
+        "lastModified": 1673896279,
+        "narHash": "sha256-asIn7cl96r8gHsUsMvfwdUXVGfEOh1BuVMw9ueu7vd0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "0d76b94c90a20c20d3e57ea1ab03d9afa00dee72",
+        "rev": "455ef0c806b96420f9fcda053cc0b1d707800b0c",
         "type": "github"
       },
       "original": {

--- a/home/modules/shell/neovim.nix
+++ b/home/modules/shell/neovim.nix
@@ -24,6 +24,7 @@ in
         # cmake-language-server
         # elmPackages.elm-language-server
         efm-lsp
+        marksman
         nodePackages.bash-language-server
         nodePackages.pyright
         nodePackages.typescript-language-server

--- a/nix/overlays/neovim/default.nix
+++ b/nix/overlays/neovim/default.nix
@@ -1,21 +1,32 @@
 { inputs, ... }:
 _final: prev:
 
+# NixOS/nixpkgs#208103 introduced a patch that makes builds reproduceable.
+# This patch applies to the current 0.8.2 but does not apply to nightly.
+# Filtering out this patch.
+let
+  patchFilter = v: builtins.filter
+    (p:
+      let patch = if builtins.typeOf p == "set" then baseNameOf p.name else baseNameOf p;
+      in patch != "neovim-build-make-generated-source-files-reproducible.patch"
+    )
+    v;
+in
 {
   neovim-unwrapped = inputs.neovim-flake.packages.${prev.system}.neovim.overrideAttrs (old: {
-    patches = old.patches ++ [ ./0001-Add-nix-short-rev-to-pre-release-version-info.patch ];
+    patches = patchFilter old.patches ++ [ ./0001-Add-nix-short-rev-to-pre-release-version-info.patch ];
     NIX_SHORT_REV = inputs.neovim-flake.shortRev;
   });
   neovim-nightly = inputs.neovim-flake.packages.${prev.system}.neovim.overrideAttrs (old: {
-    patches = old.patches ++ [ ./0001-Add-nix-short-rev-to-pre-release-version-info.patch ];
+    patches = patchFilter old.patches ++ [ ./0001-Add-nix-short-rev-to-pre-release-version-info.patch ];
     NIX_SHORT_REV = inputs.neovim-flake.shortRev;
   });
   neovim-debug = inputs.neovim-flake.packages.${prev.system}.neovim-debug.overrideAttrs (old: {
-    patches = old.patches ++ [ ./0001-Add-nix-short-rev-to-pre-release-version-info.patch ];
+    patches = patchFilter old.patches ++ [ ./0001-Add-nix-short-rev-to-pre-release-version-info.patch ];
     NIX_SHORT_REV = inputs.neovim-flake.shortRev;
   });
   neovim-developer = inputs.neovim-flake.packages.${prev.system}.neovim-developer.overrideAttrs (old: {
-    patches = old.patches ++ [ ./0001-Add-nix-short-rev-to-pre-release-version-info.patch ];
+    patches = patchFilter old.patches ++ [ ./0001-Add-nix-short-rev-to-pre-release-version-info.patch ];
     NIX_SHORT_REV = inputs.neovim-flake.shortRev;
   });
 }


### PR DESCRIPTION
Flake lock file updates:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/267040e7a2b8644f1fdfcf57b7e808c286dbdc7b' (2022-12-24)
  → 'github:lnl7/nix-darwin/87b9d090ad39b25b2400029c64825fc2a8868943' (2023-01-09)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/d6f9bdfb4a25395b15f6c6feba3d0bba5e62b3ce' (2022-12-31)
  → 'github:nix-community/fenix/a9a262cbec1f1c3f771071fd1a246ee05811f5a1' (2023-01-17)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/0d76b94c90a20c20d3e57ea1ab03d9afa00dee72' (2022-12-30)
  → 'github:rust-lang/rust-analyzer/455ef0c806b96420f9fcda053cc0b1d707800b0c' (2023-01-16)
 - Updated `np`: `flake-compat` ➡️ ``
    'github:edolstra/flake-compat/009399224d5e398d03b22badca40a37ac85412a1' (2022-11-17)
  → 'github:edolstra/flake-compat/35bb57c0c8d8b62bbfd284272c928ceb64ddbde9' (2023-01-17)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/dd99675ee81fef051809bc87d67eb07f5ba022e8' (2022-12-29)
  → 'github:nix-community/home-manager/bd3efacb82c721edad1ce9eda583df5fb62ab00a' (2023-01-17)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/6ba34e21fee2a81677e8261dfeaf24c8cd320500?dir=contrib' (2022-12-31)
  → 'github:neovim/neovim/0aae7f386042593aecfc8237020899d0e94fe8e4?dir=contrib' (2023-01-18)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/677ed08a50931e38382dbef01cba08a8f7eac8f6' (2022-12-29)
  → 'github:nixos/nixpkgs/6dccdc458512abce8d19f74195bb20fdb067df50' (2023-01-15)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/03b39de5cf7569eab4492e895a4473983bf3a917' (2023-01-01)
  → 'github:nix-community/nur/993b34d7fc525534c59229312c1ff21a976def54' (2023-01-18)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/e56c01d0e22149db08ef28efcaaef27839852970' (2023-01-01)
  → 'github:nushell/nushell/be32aeee70a6d004abbab3e2db229d6246f0f0fd' (2023-01-18)