### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1673936585,
-        "narHash": "sha256-5fDrM+jPUvXIFnw/72zk/05wfNTXItiG1WhF+1dok1w=",
+        "lastModified": 1674282107,
+        "narHash": "sha256-0wBK+1IMJdAkckR715ssMPFUhCAqRpRcppGwraiWREU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "a9a262cbec1f1c3f771071fd1a246ee05811f5a1",
+        "rev": "18fc1446c44e05165437c5900b95670166a09270",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1673948101,
-        "narHash": "sha256-cD0OzFfnLFeeaz4jVszH9QiMTn+PBxmcYzrp+xujpwM=",
+        "lastModified": 1674250603,
+        "narHash": "sha256-SBolFspxBHpW3hCCDNAFXUiO2mucmkVmf17UmSIK3Cs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd3efacb82c721edad1ce9eda583df5fb62ab00a",
+        "rev": "275ab728912006eecb549338a50f24f294a7cfb7",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1674014440,
-        "narHash": "sha256-mtnizpeeEQd8R0P3PzsEUhvsJLyOZArFfd561+XFGtk=",
+        "lastModified": 1674357598,
+        "narHash": "sha256-6ukUxxS+cvSbsioJwkYiqpl4cDZkWi/KyII0OMJLgdc=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "0aae7f386042593aecfc8237020899d0e94fe8e4",
+        "rev": "18fb669b9be1e7dac73dc3d97c2e3e7fd4013099",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673796341,
-        "narHash": "sha256-1kZi9OkukpNmOaPY7S5/+SlCDOuYnP3HkXHvNDyLQcc=",
+        "lastModified": 1674211260,
+        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6dccdc458512abce8d19f74195bb20fdb067df50",
+        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674021312,
-        "narHash": "sha256-kW00Hpb2jqX7zDHnw/us7DH4lChTa6DoVcZZrd9CKwE=",
+        "lastModified": 1674360560,
+        "narHash": "sha256-p/YGX2UVjyqQIm07OMMQQ2i+elWafbFexIPkROs0t9Q=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "993b34d7fc525534c59229312c1ff21a976def54",
+        "rev": "623ab5debd683264eb5ede3754c6a13a7fa475ec",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1674006655,
-        "narHash": "sha256-ZY2B7zcu0eg5cpKD+14faCkO2hiRfCYpJekrXtJmho4=",
+        "lastModified": 1674349529,
+        "narHash": "sha256-HHC0WGFLju4GUEht6azeeS/1QdH3/ZuTTqzP5U8N4kc=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "be32aeee70a6d004abbab3e2db229d6246f0f0fd",
+        "rev": "b97bfe9297bed4c6063cdd27af0ac4ffe6c065ec",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1673896279,
-        "narHash": "sha256-asIn7cl96r8gHsUsMvfwdUXVGfEOh1BuVMw9ueu7vd0=",
+        "lastModified": 1674253028,
+        "narHash": "sha256-OzdEJpxIZw50DuZ1aBJlZnJ/GxHfKhexhn4Eu53YnEo=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "455ef0c806b96420f9fcda053cc0b1d707800b0c",
+        "rev": "9a6294d7038e7eab00beafdf64ec4aa50a4c66a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/a9a262cbec1f1c3f771071fd1a246ee05811f5a1' (2023-01-17)
  → 'github:nix-community/fenix/18fc1446c44e05165437c5900b95670166a09270' (2023-01-21)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/455ef0c806b96420f9fcda053cc0b1d707800b0c' (2023-01-16)
  → 'github:rust-lang/rust-analyzer/9a6294d7038e7eab00beafdf64ec4aa50a4c66a2' (2023-01-20)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/bd3efacb82c721edad1ce9eda583df5fb62ab00a' (2023-01-17)
  → 'github:nix-community/home-manager/275ab728912006eecb549338a50f24f294a7cfb7' (2023-01-20)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/0aae7f386042593aecfc8237020899d0e94fe8e4?dir=contrib' (2023-01-18)
  → 'github:neovim/neovim/18fb669b9be1e7dac73dc3d97c2e3e7fd4013099?dir=contrib' (2023-01-22)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/6dccdc458512abce8d19f74195bb20fdb067df50' (2023-01-15)
  → 'github:nixos/nixpkgs/5ed481943351e9fd354aeb557679624224de38d5' (2023-01-20)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/993b34d7fc525534c59229312c1ff21a976def54' (2023-01-18)
  → 'github:nix-community/nur/623ab5debd683264eb5ede3754c6a13a7fa475ec' (2023-01-22)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/be32aeee70a6d004abbab3e2db229d6246f0f0fd' (2023-01-18)
  → 'github:nushell/nushell/b97bfe9297bed4c6063cdd27af0ac4ffe6c065ec' (2023-01-22)