### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673295039,
-        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
+        "lastModified": 1680266963,
+        "narHash": "sha256-IW/lzbUCOcldLHWHjNSg1YoViDnZOmz0ZJL7EH9OkV8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
+        "rev": "99d4187d11be86b49baa3a1aec0530004072374f",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1674282107,
-        "narHash": "sha256-0wBK+1IMJdAkckR715ssMPFUhCAqRpRcppGwraiWREU=",
+        "lastModified": 1680330049,
+        "narHash": "sha256-hXwhRY3E26ZOXQKe9BJYHjnGXwv/qC9L56QGJJhzh3c=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "18fc1446c44e05165437c5900b95670166a09270",
+        "rev": "014c1e43bdc77936ed92bb63ddf151b6b69f0d88",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1674250603,
-        "narHash": "sha256-SBolFspxBHpW3hCCDNAFXUiO2mucmkVmf17UmSIK3Cs=",
+        "lastModified": 1680389554,
+        "narHash": "sha256-+8FUmS4GbDMynQErZGXKg+wU76rq6mI5fprxFXFWKSM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "275ab728912006eecb549338a50f24f294a7cfb7",
+        "rev": "ddd8866c0306c48f465e7f48432e6f1ecd1da7f8",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1674357598,
-        "narHash": "sha256-6ukUxxS+cvSbsioJwkYiqpl4cDZkWi/KyII0OMJLgdc=",
+        "lastModified": 1680365231,
+        "narHash": "sha256-vynHWSNc4tHnB2Dv7EvGTO5so3T9fEZJ+mPjTFifk5s=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "18fb669b9be1e7dac73dc3d97c2e3e7fd4013099",
+        "rev": "9084948893f9c1669ab56061c8d04adabbb6c3cf",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674211260,
-        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
+        "lastModified": 1680213900,
+        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
+        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1674360560,
-        "narHash": "sha256-p/YGX2UVjyqQIm07OMMQQ2i+elWafbFexIPkROs0t9Q=",
+        "lastModified": 1680408553,
+        "narHash": "sha256-4jVTOt4hFMqpDH3WvJK9mHTWGkL8vka6Us0zRyzaIbY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "623ab5debd683264eb5ede3754c6a13a7fa475ec",
+        "rev": "dd60c4592d03d8607c4fd359593260570eaa6f49",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1674349529,
-        "narHash": "sha256-HHC0WGFLju4GUEht6azeeS/1QdH3/ZuTTqzP5U8N4kc=",
+        "lastModified": 1680378525,
+        "narHash": "sha256-pnRzCEdk+bochFsUug4YPlwfrHGIFyf8AgLS82d33Bw=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "b97bfe9297bed4c6063cdd27af0ac4ffe6c065ec",
+        "rev": "0b9fc4ff3a502135be928fc09bfc9412c87fc5a6",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1674253028,
-        "narHash": "sha256-OzdEJpxIZw50DuZ1aBJlZnJ/GxHfKhexhn4Eu53YnEo=",
+        "lastModified": 1680267680,
+        "narHash": "sha256-atC3zkM5nBXdBFE1+Xoxpm/Ye42j/Rq12IR0qi5+/ao=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "9a6294d7038e7eab00beafdf64ec4aa50a4c66a2",
+        "rev": "853fb44a24b8d3341f52747caa949013121b24b4",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {

--- a/home/modules/app/firefox.nix
+++ b/home/modules/app/firefox.nix
@@ -22,32 +22,37 @@ in
   };
 
   config = mkIf cfg.enable {
-    programs.firefox = {
-      enable = true;
-      extensions = with pkgs.nur.repos.rycee.firefox-addons; [
-        darkreader
-        privacy-badger
-        tree-style-tab
-        ublock-origin
-        vimium
-      ];
-      profiles = {
-        home = {
-          id = 0;
-          settings = defaultSettings // {
-            "browser.urlbar.placeholderName" = "DuckDuckGo";
-            "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+    programs.firefox =
+      let
+        extensions = with pkgs.nur.repos.rycee.firefox-addons; [
+          darkreader
+          privacy-badger
+          tree-style-tab
+          ublock-origin
+          vimium
+        ];
+      in
+      {
+        enable = true;
+        profiles = {
+          home = {
+            inherit extensions;
+            id = 0;
+            settings = defaultSettings // {
+              "browser.urlbar.placeholderName" = "DuckDuckGo";
+              "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+            };
           };
-        };
 
-        work = {
-          id = 1;
-          settings = defaultSettings // {
-            "browser.startup.homepage" = "about:blank";
+          work = {
+            inherit extensions;
+            id = 1;
+            settings = defaultSettings // {
+              "browser.startup.homepage" = "about:blank";
+            };
           };
         };
       };
-    };
   };
   # config = mkIf cfg.enable {
   #   programs.firefox = {

--- a/system/common/modules/user/default.nix
+++ b/system/common/modules/user/default.nix
@@ -21,10 +21,13 @@ in
   };
 
   config = mkMerge [
-    (
-      mkIf (cfg.home != null) {
-        home-manager.users."${cfg.name}" = mkUserHome { inherit system; config = cfg.home; };
-      }
-    )
+    (mkIf (cfg.home != null) {
+      home-manager.users."${cfg.name}" = mkUserHome { inherit system; config = cfg.home; };
+    })
+
+    {
+      # Enable zsh in order to add /run/current-system/sw/bin to $PATH
+      programs.zsh.enable = true;
+    }
   ];
 }


### PR DESCRIPTION
Flake lock file updates:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/87b9d090ad39b25b2400029c64825fc2a8868943' (2023-01-09)
  → 'github:lnl7/nix-darwin/99d4187d11be86b49baa3a1aec0530004072374f' (2023-03-31)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/18fc1446c44e05165437c5900b95670166a09270' (2023-01-21)
  → 'github:nix-community/fenix/014c1e43bdc77936ed92bb63ddf151b6b69f0d88' (2023-04-01)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/9a6294d7038e7eab00beafdf64ec4aa50a4c66a2' (2023-01-20)
  → 'github:rust-lang/rust-analyzer/853fb44a24b8d3341f52747caa949013121b24b4' (2023-03-31)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/275ab728912006eecb549338a50f24f294a7cfb7' (2023-01-20)
  → 'github:nix-community/home-manager/ddd8866c0306c48f465e7f48432e6f1ecd1da7f8' (2023-04-01)
 - Updated `np`: `home-manager/utils` ➡️ ``
    'github:numtide/flake-utils/5aed5285a952e0b949eb3ba02c12fa4fcfef535f' (2022-11-02)
  → 'github:numtide/flake-utils/3db36a8b464d0c4532ba1c7dda728f4576d6d073' (2023-02-13)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/18fb669b9be1e7dac73dc3d97c2e3e7fd4013099?dir=contrib' (2023-01-22)
  → 'github:neovim/neovim/9084948893f9c1669ab56061c8d04adabbb6c3cf?dir=contrib' (2023-04-01)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/5ed481943351e9fd354aeb557679624224de38d5' (2023-01-20)
  → 'github:nixos/nixpkgs/e3652e0735fbec227f342712f180f4f21f0594f2' (2023-03-30)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/623ab5debd683264eb5ede3754c6a13a7fa475ec' (2023-01-22)
  → 'github:nix-community/nur/dd60c4592d03d8607c4fd359593260570eaa6f49' (2023-04-02)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/b97bfe9297bed4c6063cdd27af0ac4ffe6c065ec' (2023-01-22)
  → 'github:nushell/nushell/0b9fc4ff3a502135be928fc09bfc9412c87fc5a6' (2023-04-01)