### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680266963,
-        "narHash": "sha256-IW/lzbUCOcldLHWHjNSg1YoViDnZOmz0ZJL7EH9OkV8=",
+        "lastModified": 1681154394,
+        "narHash": "sha256-avnu1K9AuouygBiwVKuDp6emiTET43az3rcpv0ctLjc=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "99d4187d11be86b49baa3a1aec0530004072374f",
+        "rev": "025912529dd0b31dead95519e944ea05f1ad56f2",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1680330049,
-        "narHash": "sha256-hXwhRY3E26ZOXQKe9BJYHjnGXwv/qC9L56QGJJhzh3c=",
+        "lastModified": 1681107727,
+        "narHash": "sha256-49r7llR0lRrZLC2uBiRgXN0Ds1kfH7JgBfH5+sQAGio=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "014c1e43bdc77936ed92bb63ddf151b6b69f0d88",
+        "rev": "4869bb2408e6778840c8d00be4b45d8353f24723",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1680389554,
-        "narHash": "sha256-+8FUmS4GbDMynQErZGXKg+wU76rq6mI5fprxFXFWKSM=",
+        "lastModified": 1681162249,
+        "narHash": "sha256-jh5fLaTxR5XowXA0CN/1Gs2qbvVdmdPCSeO424XWZLI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ddd8866c0306c48f465e7f48432e6f1ecd1da7f8",
+        "rev": "4e79c6a414ce59fd1a53ab77899c77ab87774e6b",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1680365231,
-        "narHash": "sha256-vynHWSNc4tHnB2Dv7EvGTO5so3T9fEZJ+mPjTFifk5s=",
+        "lastModified": 1681163182,
+        "narHash": "sha256-q9497ycmUiFzGZWtK7OOfmkSikQq+Ww/sPXsrVv9uRk=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "9084948893f9c1669ab56061c8d04adabbb6c3cf",
+        "rev": "03a021f378e8ca019e36dc6a3248a63edf19f8ad",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680213900,
-        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
+        "lastModified": 1681036984,
+        "narHash": "sha256-AbScJXshYzbeUKHh+Y3OICc3iAtr+NqJ3Xb81GW+ptU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
+        "rev": "fd531dee22c9a3d4336cc2da39e8dd905e8f3de4",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680408553,
-        "narHash": "sha256-4jVTOt4hFMqpDH3WvJK9mHTWGkL8vka6Us0zRyzaIbY=",
+        "lastModified": 1681165201,
+        "narHash": "sha256-qDv4azcgcnqoEA1wtn83h08DfhxqtZgBbYGzzSViQiM=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "dd60c4592d03d8607c4fd359593260570eaa6f49",
+        "rev": "bcaa53b2aac01194ad59cd385286844c03322f72",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1680378525,
-        "narHash": "sha256-pnRzCEdk+bochFsUug4YPlwfrHGIFyf8AgLS82d33Bw=",
+        "lastModified": 1681163571,
+        "narHash": "sha256-XxwwvRyMdES+qbryD0eO8XkizrGaN9oj8KjiRNXxsRI=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "0b9fc4ff3a502135be928fc09bfc9412c87fc5a6",
+        "rev": "eb4d19fb9cc1b997f297662b1ada2f3069220927",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1680267680,
-        "narHash": "sha256-atC3zkM5nBXdBFE1+Xoxpm/Ye42j/Rq12IR0qi5+/ao=",
+        "lastModified": 1680884353,
+        "narHash": "sha256-efcZC+/FH3ZXMgDL3K5RIzKeD0Ow1ci096cXkTsP8SQ=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "853fb44a24b8d3341f52747caa949013121b24b4",
+        "rev": "01120f1213ad928de7300a8acf9f41bed72d0422",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/99d4187d11be86b49baa3a1aec0530004072374f' (2023-03-31)
  → 'github:lnl7/nix-darwin/025912529dd0b31dead95519e944ea05f1ad56f2' (2023-04-10)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/014c1e43bdc77936ed92bb63ddf151b6b69f0d88' (2023-04-01)
  → 'github:nix-community/fenix/4869bb2408e6778840c8d00be4b45d8353f24723' (2023-04-10)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/853fb44a24b8d3341f52747caa949013121b24b4' (2023-03-31)
  → 'github:rust-lang/rust-analyzer/01120f1213ad928de7300a8acf9f41bed72d0422' (2023-04-07)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/ddd8866c0306c48f465e7f48432e6f1ecd1da7f8' (2023-04-01)
  → 'github:nix-community/home-manager/4e79c6a414ce59fd1a53ab77899c77ab87774e6b' (2023-04-10)
 - Updated `np`: `home-manager/utils` ➡️ ``
    'github:numtide/flake-utils/3db36a8b464d0c4532ba1c7dda728f4576d6d073' (2023-02-13)
  → 'github:numtide/flake-utils/93a2b84fc4b70d9e089d029deacc3583435c2ed6' (2023-03-15)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/9084948893f9c1669ab56061c8d04adabbb6c3cf?dir=contrib' (2023-04-01)
  → 'github:neovim/neovim/03a021f378e8ca019e36dc6a3248a63edf19f8ad?dir=contrib' (2023-04-10)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/e3652e0735fbec227f342712f180f4f21f0594f2' (2023-03-30)
  → 'github:nixos/nixpkgs/fd531dee22c9a3d4336cc2da39e8dd905e8f3de4' (2023-04-09)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/dd60c4592d03d8607c4fd359593260570eaa6f49' (2023-04-02)
  → 'github:nix-community/nur/bcaa53b2aac01194ad59cd385286844c03322f72' (2023-04-10)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/0b9fc4ff3a502135be928fc09bfc9412c87fc5a6' (2023-04-01)
  → 'github:nushell/nushell/eb4d19fb9cc1b997f297662b1ada2f3069220927' (2023-04-10)