### PR TITLE
chore(flake): Automatic flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681154394,
-        "narHash": "sha256-avnu1K9AuouygBiwVKuDp6emiTET43az3rcpv0ctLjc=",
+        "lastModified": 1686307493,
+        "narHash": "sha256-R4VEFnDn7nRmNxAu1LwNbjns5DPM8IBsvnrWmZ8ymPs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "025912529dd0b31dead95519e944ea05f1ad56f2",
+        "rev": "7c16d31383a90e0e72ace0c35d2d66a18f90fb4f",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1681567221,
-        "narHash": "sha256-npJIhn0cn0D1P6pkkHJOYCvM04SoVhBrcVXUrxD+zIU=",
+        "lastModified": 1686378027,
+        "narHash": "sha256-YFCMg/lMq44Us9G6PVu3PJx5/xvWCKV3yu8v2q1MNdk=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "94e14fb51056a020a7d8cf44518cca09ba270363",
+        "rev": "d6f69b3caa16f2de0ceb2f991e5e45fd80e17a52",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681586243,
-        "narHash": "sha256-vdP79IZuDZVNSl4RN1LgEuab1Tkbv4gCxiE8VLdRf7U=",
+        "lastModified": 1686391840,
+        "narHash": "sha256-5S0APl6Mfm6a37taHwvuf11UHnAX0+PnoWQbsYbMUnc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "40ebb62101c83de81e5fd7c3cfe5cea2ed21b1ad",
+        "rev": "0144ac418ef633bfc9dbd89b8c199ad3a617c59f",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1681612931,
-        "narHash": "sha256-EPAchvYTJTyhyfCPD2MvzJZrrmvcYX2fFYgaDazdHA4=",
+        "lastModified": 1686457391,
+        "narHash": "sha256-3pjrwIIv1B2Eudj3NfsNpvYMxode/pdo0Ps1+ucj3VI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "54dab9ed9e200f7c5bcac4a8f4901770fa15fa4f",
+        "rev": "4229bbe514b7a1bc5b9f888a294cc8a323a7d869",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681465517,
-        "narHash": "sha256-EasJh15/jcJNAHtq2SGbiADRXteURAnQbj1NqBoKkzU=",
+        "lastModified": 1686412476,
+        "narHash": "sha256-inl9SVk6o5h75XKC79qrDCAobTD1Jxh6kVYTZKHzewA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "abe7316dd51a313ce528972b104f4f04f56eefc4",
+        "rev": "21951114383770f96ae528d0ae68824557768e81",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1681618215,
-        "narHash": "sha256-5tEzso6ZGw+bM4r1acy6js8ZbE1bryUpqFz2KEbYRm0=",
+        "lastModified": 1686459243,
+        "narHash": "sha256-UbIzogWlBGS47OtPG2EXSpNFsxRrjeXeYF2UAFXQom8=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "acc7c1778eb3e81523da0e4ba334110809eaf0ac",
+        "rev": "708f8138a900f80f574af6344cbfbd1ca698f2ac",
         "type": "github"
       },
       "original": {
@@ -150,11 +150,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1681609192,
-        "narHash": "sha256-35at6cin4m1xdyiqtZikV/Gcpoaj4RjXH+7Z/T2Cla4=",
+        "lastModified": 1686436691,
+        "narHash": "sha256-sXu7IN3+FmAh0JMhbRdFGP0+EPaFj+/jFSEmYnZ2ed0=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "6b3236715b56450fdfdebed0927d96b72730d3d2",
+        "rev": "be53ecbbaad523056d772c3325cbea60cb54fa8e",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1681478629,
-        "narHash": "sha256-z8RTNp3kAVYYtY/mKdS5Elrohmt8tjWyigBzeYbNuV4=",
+        "lastModified": 1686354634,
+        "narHash": "sha256-QMENWrUFF96O4JaxibfmXBjBRlCTP/wrA6m9iffGmRQ=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "b218009f46dd012abcd2d9c2656c3dc498075368",
+        "rev": "5f8a6f67b955056070ba5d0675ff59d2305fbace",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

 - Updated `np`: `darwin` ➡️ ``
    'github:lnl7/nix-darwin/025912529dd0b31dead95519e944ea05f1ad56f2' (2023-04-10)
  → 'github:lnl7/nix-darwin/7c16d31383a90e0e72ace0c35d2d66a18f90fb4f' (2023-06-09)
 - Updated `np`: `fenix` ➡️ ``
    'github:nix-community/fenix/94e14fb51056a020a7d8cf44518cca09ba270363' (2023-04-15)
  → 'github:nix-community/fenix/d6f69b3caa16f2de0ceb2f991e5e45fd80e17a52' (2023-06-10)
 - Updated `np`: `fenix/rust-analyzer-src` ➡️ ``
    'github:rust-lang/rust-analyzer/b218009f46dd012abcd2d9c2656c3dc498075368' (2023-04-14)
  → 'github:rust-lang/rust-analyzer/5f8a6f67b955056070ba5d0675ff59d2305fbace' (2023-06-09)
 - Updated `np`: `home-manager` ➡️ ``
    'github:nix-community/home-manager/40ebb62101c83de81e5fd7c3cfe5cea2ed21b1ad' (2023-04-15)
  → 'github:nix-community/home-manager/0144ac418ef633bfc9dbd89b8c199ad3a617c59f' (2023-06-10)
 - Updated `np`: `neovim-flake` ➡️ ``
    'github:neovim/neovim/54dab9ed9e200f7c5bcac4a8f4901770fa15fa4f?dir=contrib' (2023-04-16)
  → 'github:neovim/neovim/4229bbe514b7a1bc5b9f888a294cc8a323a7d869?dir=contrib' (2023-06-11)
 - Updated `np`: `nixpkgs` ➡️ ``
    'github:nixos/nixpkgs/abe7316dd51a313ce528972b104f4f04f56eefc4' (2023-04-14)
  → 'github:nixos/nixpkgs/21951114383770f96ae528d0ae68824557768e81' (2023-06-10)
 - Updated `np`: `nur` ➡️ ``
    'github:nix-community/nur/acc7c1778eb3e81523da0e4ba334110809eaf0ac' (2023-04-16)
  → 'github:nix-community/nur/708f8138a900f80f574af6344cbfbd1ca698f2ac' (2023-06-11)
 - Updated `np`: `nushell-src` ➡️ ``
    'github:nushell/nushell/6b3236715b56450fdfdebed0927d96b72730d3d2' (2023-04-16)
  → 'github:nushell/nushell/be53ecbbaad523056d772c3325cbea60cb54fa8e' (2023-06-10)