### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/config/.config/shell/sh/004-aliases.sh
+++ b/config/.config/shell/sh/004-aliases.sh
@@ -42,10 +42,10 @@ alias gs="git status -s"
 
 # if exa is installed use that for ls
 if [[ -x "$(command -v exa)" ]]; then
-  alias l="exa --group-directories-first --color=auto --git -a"
-  alias ls="exa --group-directories-first --color=auto --git"
-  alias ll="exa --group-directories-first --color=auto --git -la"
-  alias lll="exa --group-directories-first --color=auto --git -l"
+  alias l="eza --group-directories-first --color=auto --git -a"
+  alias ls="eza --group-directories-first --color=auto --git"
+  alias ll="eza --group-directories-first --color=auto --git -la"
+  alias lll="eza --group-directories-first --color=auto --git -l"
 else
   # have to check if we are on a bsd system (cough, cough... mac) as
   # it does not have color mode because of course...

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686307493,
-        "narHash": "sha256-R4VEFnDn7nRmNxAu1LwNbjns5DPM8IBsvnrWmZ8ymPs=",
+        "lastModified": 1694497842,
+        "narHash": "sha256-z03v/m0OwcLBok97KcUgMl8ZFw5Xwsi2z+n6nL7JdXY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "7c16d31383a90e0e72ace0c35d2d66a18f90fb4f",
+        "rev": "4496ab26628c5f43d2a5c577a06683c753e32fe2",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1686637310,
-        "narHash": "sha256-sGfKyioVsxQppDM0eDO62wtFiz+bZOD0cBMMIEjqn4I=",
+        "lastModified": 1694586081,
+        "narHash": "sha256-DNAohcMcTJNiFJ2hTTS6R+yaqVU+QVzp1uRsz0Ctiac=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "6fbeedcd2fc1fba77152e13fd7492824d77a4060",
+        "rev": "b16b1f21654b9490c662f6fd0a8fe3774a4b1606",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686666715,
-        "narHash": "sha256-lBYoA/AI22znVdwuRd1yFwixeAT9m0oudP4TVdhJiC0=",
+        "lastModified": 1694642908,
+        "narHash": "sha256-0Opzs/56VW03COlVdoBrHJZGxQ7gzLDEWADnccC8ras=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4aa9fd83b5c2d43b3c9c9de979a8675fcb8e563",
+        "rev": "b62f549653e97d78392c1e282b8ca76546a86585",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1686669455,
-        "narHash": "sha256-yu7NZhZEn4tx5cy9/WmsN3SOtx9thinEi5cif4GLjCs=",
+        "lastModified": 1694648542,
+        "narHash": "sha256-ktzCb7bmhW7DWtBuqQaZN32mGtNiXsydd1TrVkmxS+g=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "bc67bbe4469b777a958f5ad515dec777777e9f2d",
+        "rev": "f5953edbac14febce9d4f8a3c35bdec1eae26fbe",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686501370,
-        "narHash": "sha256-G0WuM9fqTPRc2URKP9Lgi5nhZMqsfHGrdEbrLvAPJcg=",
+        "lastModified": 1694422566,
+        "narHash": "sha256-lHJ+A9esOz9vln/3CJG23FV6Wd2OoOFbDeEs4cMGMqc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "75a5ebf473cd60148ba9aec0d219f72e5cf52519",
+        "rev": "3a2786eea085f040a66ecde1bc3ddc7099f6dbeb",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1686685543,
-        "narHash": "sha256-84fmoTO7yBn2GYG7vWM/wCV7yS3Z0PYdnWj1cOvvwLI=",
+        "lastModified": 1694655751,
+        "narHash": "sha256-JSxVde+pc/pX9WvystrOpZwltiOjwX9D6lkuDmWA2ZE=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "b6cfdb6488f02ea5bcecf4bea2cbed8f134c5481",
+        "rev": "79268b248b40b5e056f5b11d892cde341f22a637",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1686681180,
-        "narHash": "sha256-2ZInsCeK2bp86343Oz499971tC4W6I8tggsoleMRf1M=",
+        "lastModified": 1694643509,
+        "narHash": "sha256-AIRulxRfrjulQpw2/NXkL18hIGEg14z6/aPqP7/zgcc=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "2b181bf69c563c628d21a2957ab1b8057988dd44",
+        "rev": "026e18399ea8ba1819c75ea2afcea4e8cf10b4d2",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1686586902,
-        "narHash": "sha256-+zfBFBmUxWutKbhdntI9uvF4D5Rh7BhcByM2l+ReyTw=",
+        "lastModified": 1694553088,
+        "narHash": "sha256-vnPa/OueHI+Dx7NKB34f5SI7Mmz/VSrP+IAoGNKueU0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "1f1fe81f0db301124b3026bd2940294526cdd852",
+        "rev": "15e13561499dbe90ef07cf37a90c1cedafc53e28",
         "type": "github"
       },
       "original": {

--- a/home/modules/dev/dhall.nix
+++ b/home/modules/dev/dhall.nix
@@ -13,7 +13,6 @@ in
       dhall
       haskellPackages.dhall-bash
       haskellPackages.dhall-json
-      haskellPackages.dhall-lsp-server
       haskellPackages.dhall-yaml
     ];
   };

--- a/home/modules/shell/neovim.nix
+++ b/home/modules/shell/neovim.nix
@@ -24,7 +24,6 @@ in
       default = with pkgs; [
         # cmake-language-server
         # elmPackages.elm-language-server
-        dhall-lsp-server
         efm-lsp
         marksman
         nodePackages.bash-language-server

--- a/home/profiles/common.nix
+++ b/home/profiles/common.nix
@@ -37,7 +37,7 @@ in
         # grep alternative.
         ripgrep
         # ls alternative.
-        exa
+        eza
         # Simple, fast and user-friendly alternative to find.
         fd
         # sed alternative

--- a/system/darwin/hosts/theman/home.nix
+++ b/system/darwin/hosts/theman/home.nix
@@ -7,7 +7,7 @@
     coreutils-full
     moreutils
     ripgrep
-    exa
+    eza
     fd
     sd
     dua


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/7c16d31383a90e0e72ace0c35d2d66a18f90fb4f' (2023-06-09)
  → 'github:lnl7/nix-darwin/4496ab26628c5f43d2a5c577a06683c753e32fe2' (2023-09-12)
• Updated input 'fenix':
    'github:nix-community/fenix/6fbeedcd2fc1fba77152e13fd7492824d77a4060' (2023-06-13)
  → 'github:nix-community/fenix/b16b1f21654b9490c662f6fd0a8fe3774a4b1606' (2023-09-13)
• Updated input 'fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/1f1fe81f0db301124b3026bd2940294526cdd852' (2023-06-12)
  → 'github:rust-lang/rust-analyzer/15e13561499dbe90ef07cf37a90c1cedafc53e28' (2023-09-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e4aa9fd83b5c2d43b3c9c9de979a8675fcb8e563' (2023-06-13)
  → 'github:nix-community/home-manager/b62f549653e97d78392c1e282b8ca76546a86585' (2023-09-13)
• Updated input 'neovim-flake':
    'github:neovim/neovim/bc67bbe4469b777a958f5ad515dec777777e9f2d?dir=contrib' (2023-06-13)
  → 'github:neovim/neovim/f5953edbac14febce9d4f8a3c35bdec1eae26fbe?dir=contrib' (2023-09-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/75a5ebf473cd60148ba9aec0d219f72e5cf52519' (2023-06-11)
  → 'github:nixos/nixpkgs/3a2786eea085f040a66ecde1bc3ddc7099f6dbeb' (2023-09-11)
• Updated input 'nur':
    'github:nix-community/nur/b6cfdb6488f02ea5bcecf4bea2cbed8f134c5481' (2023-06-13)
  → 'github:nix-community/nur/79268b248b40b5e056f5b11d892cde341f22a637' (2023-09-14)
• Updated input 'nushell-src':
    'github:nushell/nushell/2b181bf69c563c628d21a2957ab1b8057988dd44' (2023-06-13)
  → 'github:nushell/nushell/026e18399ea8ba1819c75ea2afcea4e8cf10b4d2' (2023-09-13)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`b6cfdb64` ➡️ `79268b24`](https://github.com/nix-community/nur/compare/b6cfdb6488f02ea5bcecf4bea2cbed8f134c5481...79268b248b40b5e056f5b11d892cde341f22a637) <sub>(2023-06-13 to 2023-09-14)</sub>
 - Updated input [`fenix`](https://github.com/nix-community/fenix): [`6fbeedcd` ➡️ `b16b1f21`](https://github.com/nix-community/fenix/compare/6fbeedcd2fc1fba77152e13fd7492824d77a4060...b16b1f21654b9490c662f6fd0a8fe3774a4b1606) <sub>(2023-06-13 to 2023-09-13)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`7c16d313` ➡️ `4496ab26`](https://github.com/lnl7/nix-darwin/compare/7c16d31383a90e0e72ace0c35d2d66a18f90fb4f...4496ab26628c5f43d2a5c577a06683c753e32fe2) <sub>(2023-06-09 to 2023-09-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`75a5ebf4` ➡️ `3a2786ee`](https://github.com/nixos/nixpkgs/compare/75a5ebf473cd60148ba9aec0d219f72e5cf52519...3a2786eea085f040a66ecde1bc3ddc7099f6dbeb) <sub>(2023-06-11 to 2023-09-11)</sub>
 - Updated input [`fenix/rust-analyzer-src`](https://github.com/rust-lang/rust-analyzer): [`1f1fe81f` ➡️ `15e13561`](https://github.com/rust-lang/rust-analyzer/compare/1f1fe81f0db301124b3026bd2940294526cdd852...15e13561499dbe90ef07cf37a90c1cedafc53e28) <sub>(2023-06-12 to 2023-09-12)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`bc67bbe4` ➡️ `f5953edb`](https://github.com/neovim/neovim/compare/bc67bbe4469b777a958f5ad515dec777777e9f2d...f5953edbac14febce9d4f8a3c35bdec1eae26fbe) <sub>(2023-06-13 to 2023-09-13)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`e4aa9fd8` ➡️ `b62f5496`](https://github.com/nix-community/home-manager/compare/e4aa9fd83b5c2d43b3c9c9de979a8675fcb8e563...b62f549653e97d78392c1e282b8ca76546a86585) <sub>(2023-06-13 to 2023-09-13)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`2b181bf6` ➡️ `026e1839`](https://github.com/nushell/nushell/compare/2b181bf69c563c628d21a2957ab1b8057988dd44...026e18399ea8ba1819c75ea2afcea4e8cf10b4d2) <sub>(2023-06-13 to 2023-09-13)</sub>