### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694497842,
-        "narHash": "sha256-z03v/m0OwcLBok97KcUgMl8ZFw5Xwsi2z+n6nL7JdXY=",
+        "lastModified": 1696043447,
+        "narHash": "sha256-VbJ1dY5pVH2fX1bS+cT2+4+BYEk4lMHRP0+udu9G6tk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "4496ab26628c5f43d2a5c577a06683c753e32fe2",
+        "rev": "792c2e01347cb1b2e7ec84a1ef73453ca86537d8",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696267196,
+        "narHash": "sha256-AAQ/2sD+0D18bb8hKuEEVpHUYD1GmO2Uh/taFamn6XQ=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "4f910c9827911b1ec2bf26b5a062cd09f8d89f85",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694642908,
-        "narHash": "sha256-0Opzs/56VW03COlVdoBrHJZGxQ7gzLDEWADnccC8ras=",
+        "lastModified": 1696145345,
+        "narHash": "sha256-3dM7I/d4751SLPJah0to1WBlWiyzIiuCEUwJqwBdmr4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b62f549653e97d78392c1e282b8ca76546a86585",
+        "rev": "6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1694648542,
-        "narHash": "sha256-ktzCb7bmhW7DWtBuqQaZN32mGtNiXsydd1TrVkmxS+g=",
+        "lastModified": 1696214733,
+        "narHash": "sha256-2IqDjWfqhy7MbCbFs3GDRYIpfK2usL+CYGfh6uskK/0=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "f5953edbac14febce9d4f8a3c35bdec1eae26fbe",
+        "rev": "09a17f91d0d362c6e58bfdbe3ccdeacffb0b44b9",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694422566,
-        "narHash": "sha256-lHJ+A9esOz9vln/3CJG23FV6Wd2OoOFbDeEs4cMGMqc=",
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3a2786eea085f040a66ecde1bc3ddc7099f6dbeb",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1694655751,
-        "narHash": "sha256-JSxVde+pc/pX9WvystrOpZwltiOjwX9D6lkuDmWA2ZE=",
+        "lastModified": 1696275032,
+        "narHash": "sha256-sIQvyxIk0b0gjeAUL0QSsqZPRlBAtq/Hfrfiu1nQFQw=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "79268b248b40b5e056f5b11d892cde341f22a637",
+        "rev": "94a47cbec5838634516641c5520b94ed62215111",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1694643509,
-        "narHash": "sha256-AIRulxRfrjulQpw2/NXkL18hIGEg14z6/aPqP7/zgcc=",
+        "lastModified": 1696274042,
+        "narHash": "sha256-eWu5zneMxGrt22ZcDF9y8CD/KkHRs5JI5nUniZtuqhc=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "026e18399ea8ba1819c75ea2afcea4e8cf10b4d2",
+        "rev": "783f2a93423e1b5b4297682c54bd79c1de6dc547",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/4496ab26628c5f43d2a5c577a06683c753e32fe2' (2023-09-12)
  → 'github:lnl7/nix-darwin/792c2e01347cb1b2e7ec84a1ef73453ca86537d8' (2023-09-30)
• Updated input 'flake-compat':
    'github:edolstra/flake-compat/35bb57c0c8d8b62bbfd284272c928ceb64ddbde9' (2023-01-17)
  → 'github:edolstra/flake-compat/4f910c9827911b1ec2bf26b5a062cd09f8d89f85' (2023-10-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/b62f549653e97d78392c1e282b8ca76546a86585' (2023-09-13)
  → 'github:nix-community/home-manager/6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30' (2023-10-01)
• Updated input 'neovim-flake':
    'github:neovim/neovim/f5953edbac14febce9d4f8a3c35bdec1eae26fbe?dir=contrib' (2023-09-13)
  → 'github:neovim/neovim/09a17f91d0d362c6e58bfdbe3ccdeacffb0b44b9?dir=contrib' (2023-10-02)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3a2786eea085f040a66ecde1bc3ddc7099f6dbeb' (2023-09-11)
  → 'github:nixos/nixpkgs/f5892ddac112a1e9b3612c39af1b72987ee5783a' (2023-09-29)
• Updated input 'nur':
    'github:nix-community/nur/79268b248b40b5e056f5b11d892cde341f22a637' (2023-09-14)
  → 'github:nix-community/nur/94a47cbec5838634516641c5520b94ed62215111' (2023-10-02)
• Updated input 'nushell-src':
    'github:nushell/nushell/026e18399ea8ba1819c75ea2afcea4e8cf10b4d2' (2023-09-13)
  → 'github:nushell/nushell/783f2a93423e1b5b4297682c54bd79c1de6dc547' (2023-10-02)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`79268b24` ➡️ `94a47cbe`](https://github.com/nix-community/nur/compare/79268b248b40b5e056f5b11d892cde341f22a637...94a47cbec5838634516641c5520b94ed62215111) <sub>(2023-09-14 to 2023-10-02)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`4496ab26` ➡️ `792c2e01`](https://github.com/lnl7/nix-darwin/compare/4496ab26628c5f43d2a5c577a06683c753e32fe2...792c2e01347cb1b2e7ec84a1ef73453ca86537d8) <sub>(2023-09-12 to 2023-09-30)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`3a2786ee` ➡️ `f5892dda`](https://github.com/nixos/nixpkgs/compare/3a2786eea085f040a66ecde1bc3ddc7099f6dbeb...f5892ddac112a1e9b3612c39af1b72987ee5783a) <sub>(2023-09-11 to 2023-09-29)</sub>
 - Updated input [`flake-compat`](https://github.com/edolstra/flake-compat): [`35bb57c0` ➡️ `4f910c98`](https://github.com/edolstra/flake-compat/compare/35bb57c0c8d8b62bbfd284272c928ceb64ddbde9...4f910c9827911b1ec2bf26b5a062cd09f8d89f85) <sub>(2023-01-17 to 2023-10-02)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`f5953edb` ➡️ `09a17f91`](https://github.com/neovim/neovim/compare/f5953edbac14febce9d4f8a3c35bdec1eae26fbe...09a17f91d0d362c6e58bfdbe3ccdeacffb0b44b9) <sub>(2023-09-13 to 2023-10-02)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`b62f5496` ➡️ `6f9b5b83`](https://github.com/nix-community/home-manager/compare/b62f549653e97d78392c1e282b8ca76546a86585...6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30) <sub>(2023-09-13 to 2023-10-01)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`026e1839` ➡️ `783f2a93`](https://github.com/nushell/nushell/compare/026e18399ea8ba1819c75ea2afcea4e8cf10b4d2...783f2a93423e1b5b4297682c54bd79c1de6dc547) <sub>(2023-09-13 to 2023-10-02)</sub>