### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696043447,
-        "narHash": "sha256-VbJ1dY5pVH2fX1bS+cT2+4+BYEk4lMHRP0+udu9G6tk=",
+        "lastModified": 1696360011,
+        "narHash": "sha256-HpPv27qMuPou4acXcZ8Klm7Zt0Elv9dgDvSJaomWb9Y=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "792c2e01347cb1b2e7ec84a1ef73453ca86537d8",
+        "rev": "8b6ea26d5d2e8359d06278364f41fbc4b903b28a",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696267196,
-        "narHash": "sha256-AAQ/2sD+0D18bb8hKuEEVpHUYD1GmO2Uh/taFamn6XQ=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "4f910c9827911b1ec2bf26b5a062cd09f8d89f85",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696145345,
-        "narHash": "sha256-3dM7I/d4751SLPJah0to1WBlWiyzIiuCEUwJqwBdmr4=",
+        "lastModified": 1696446489,
+        "narHash": "sha256-xSjMKdNR+q/3hdSPyg/LUMsZT/WIoUi8dcm5zT4SMUQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30",
+        "rev": "68f7d8c0fb0bfc67d1916dd7f06288424360d43a",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1696214733,
-        "narHash": "sha256-2IqDjWfqhy7MbCbFs3GDRYIpfK2usL+CYGfh6uskK/0=",
+        "lastModified": 1696463317,
+        "narHash": "sha256-QpxXKswmAK4QnL6CP95u3d93rVRE3IdODnLpsbVyVZM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "09a17f91d0d362c6e58bfdbe3ccdeacffb0b44b9",
+        "rev": "5f4f83ba322d2642d485669ecf762b629241d9dc",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1696193975,
+        "narHash": "sha256-mnQjUcYgp9Guu3RNVAB2Srr1TqKcPpRXmJf4LJk6KRY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "fdd898f8f79e8d2f99ed2ab6b3751811ef683242",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1696275032,
-        "narHash": "sha256-sIQvyxIk0b0gjeAUL0QSsqZPRlBAtq/Hfrfiu1nQFQw=",
+        "lastModified": 1696460286,
+        "narHash": "sha256-yitt3/KKHaZ1xyVQlbHAFhXdPY5hENfRNzQd+qWPOmo=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "94a47cbec5838634516641c5520b94ed62215111",
+        "rev": "330ca7d24da8e5e6af288b54fb1de105609ed14d",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1696274042,
-        "narHash": "sha256-eWu5zneMxGrt22ZcDF9y8CD/KkHRs5JI5nUniZtuqhc=",
+        "lastModified": 1696444249,
+        "narHash": "sha256-qug2arUVjuBhArGnT/h3vwJa/ff7zJH1CQLOdUwyvFs=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "783f2a93423e1b5b4297682c54bd79c1de6dc547",
+        "rev": "afdb68dc7175b1c6b5f4ca8f6a20b55036cb2375",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/792c2e01347cb1b2e7ec84a1ef73453ca86537d8' (2023-09-30)
  → 'github:lnl7/nix-darwin/8b6ea26d5d2e8359d06278364f41fbc4b903b28a' (2023-10-03)
• Updated input 'flake-compat':
    'github:edolstra/flake-compat/4f910c9827911b1ec2bf26b5a062cd09f8d89f85' (2023-10-02)
  → 'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30' (2023-10-01)
  → 'github:nix-community/home-manager/68f7d8c0fb0bfc67d1916dd7f06288424360d43a' (2023-10-04)
• Updated input 'neovim-flake':
    'github:neovim/neovim/09a17f91d0d362c6e58bfdbe3ccdeacffb0b44b9?dir=contrib' (2023-10-02)
  → 'github:neovim/neovim/5f4f83ba322d2642d485669ecf762b629241d9dc?dir=contrib' (2023-10-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/f5892ddac112a1e9b3612c39af1b72987ee5783a' (2023-09-29)
  → 'github:nixos/nixpkgs/fdd898f8f79e8d2f99ed2ab6b3751811ef683242' (2023-10-01)
• Updated input 'nur':
    'github:nix-community/nur/94a47cbec5838634516641c5520b94ed62215111' (2023-10-02)
  → 'github:nix-community/nur/330ca7d24da8e5e6af288b54fb1de105609ed14d' (2023-10-04)
• Updated input 'nushell-src':
    'github:nushell/nushell/783f2a93423e1b5b4297682c54bd79c1de6dc547' (2023-10-02)
  → 'github:nushell/nushell/afdb68dc7175b1c6b5f4ca8f6a20b55036cb2375' (2023-10-04)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`94a47cbe` ➡️ `330ca7d2`](https://github.com/nix-community/nur/compare/94a47cbec5838634516641c5520b94ed62215111...330ca7d24da8e5e6af288b54fb1de105609ed14d) <sub>(2023-10-02 to 2023-10-04)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`792c2e01` ➡️ `8b6ea26d`](https://github.com/lnl7/nix-darwin/compare/792c2e01347cb1b2e7ec84a1ef73453ca86537d8...8b6ea26d5d2e8359d06278364f41fbc4b903b28a) <sub>(2023-09-30 to 2023-10-03)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`f5892dda` ➡️ `fdd898f8`](https://github.com/nixos/nixpkgs/compare/f5892ddac112a1e9b3612c39af1b72987ee5783a...fdd898f8f79e8d2f99ed2ab6b3751811ef683242) <sub>(2023-09-29 to 2023-10-01)</sub>
 - Updated input [`flake-compat`](https://github.com/edolstra/flake-compat): [`4f910c98` ➡️ `0f9255e0`](https://github.com/edolstra/flake-compat/compare/4f910c9827911b1ec2bf26b5a062cd09f8d89f85...0f9255e01c2351cc7d116c072cb317785dd33b33) <sub>(2023-10-02 to 2023-10-04)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`09a17f91` ➡️ `5f4f83ba`](https://github.com/neovim/neovim/compare/09a17f91d0d362c6e58bfdbe3ccdeacffb0b44b9...5f4f83ba322d2642d485669ecf762b629241d9dc) <sub>(2023-10-02 to 2023-10-04)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`6f9b5b83` ➡️ `68f7d8c0`](https://github.com/nix-community/home-manager/compare/6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30...68f7d8c0fb0bfc67d1916dd7f06288424360d43a) <sub>(2023-10-01 to 2023-10-04)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`783f2a93` ➡️ `afdb68dc`](https://github.com/nushell/nushell/compare/783f2a93423e1b5b4297682c54bd79c1de6dc547...afdb68dc7175b1c6b5f4ca8f6a20b55036cb2375) <sub>(2023-10-02 to 2023-10-04)</sub>