### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696043447,
-        "narHash": "sha256-VbJ1dY5pVH2fX1bS+cT2+4+BYEk4lMHRP0+udu9G6tk=",
+        "lastModified": 1696360011,
+        "narHash": "sha256-HpPv27qMuPou4acXcZ8Klm7Zt0Elv9dgDvSJaomWb9Y=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "792c2e01347cb1b2e7ec84a1ef73453ca86537d8",
+        "rev": "8b6ea26d5d2e8359d06278364f41fbc4b903b28a",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696267196,
-        "narHash": "sha256-AAQ/2sD+0D18bb8hKuEEVpHUYD1GmO2Uh/taFamn6XQ=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "4f910c9827911b1ec2bf26b5a062cd09f8d89f85",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696145345,
-        "narHash": "sha256-3dM7I/d4751SLPJah0to1WBlWiyzIiuCEUwJqwBdmr4=",
+        "lastModified": 1696940889,
+        "narHash": "sha256-p2Wic74A1tZpFcld1wSEbFQQbrZ/tPDuLieCnspamQo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30",
+        "rev": "6bba64781e4b7c1f91a733583defbd3e46b49408",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1696214733,
-        "narHash": "sha256-2IqDjWfqhy7MbCbFs3GDRYIpfK2usL+CYGfh6uskK/0=",
+        "lastModified": 1696958432,
+        "narHash": "sha256-yPhORnQjwEFGEswA5Y6bzF6iM0fgje1MLggyVDSz6Io=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "09a17f91d0d362c6e58bfdbe3ccdeacffb0b44b9",
+        "rev": "c3d21ad1bccd9a2975be73b1115213fd884eada3",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1696604326,
+        "narHash": "sha256-YXUNI0kLEcI5g8lqGMb0nh67fY9f2YoJsILafh6zlMo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "87828a0e03d1418e848d3dd3f3014a632e4a4f64",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1696275032,
-        "narHash": "sha256-sIQvyxIk0b0gjeAUL0QSsqZPRlBAtq/Hfrfiu1nQFQw=",
+        "lastModified": 1696957813,
+        "narHash": "sha256-01MpPV+9dfB+wlsPOKdfjpZ6ybtwNtEafjvmNISiYpY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "94a47cbec5838634516641c5520b94ed62215111",
+        "rev": "4f04090f1d14f608eb7c3f4205001e88c33590a3",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1696274042,
-        "narHash": "sha256-eWu5zneMxGrt22ZcDF9y8CD/KkHRs5JI5nUniZtuqhc=",
+        "lastModified": 1696961144,
+        "narHash": "sha256-wrRQfdH7aH6Q17gI+zsWPQaX9LVlekkC2sHpPauVrrU=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "783f2a93423e1b5b4297682c54bd79c1de6dc547",
+        "rev": "8c36e9df44ca483a3d3b07264c189155903681a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/792c2e01347cb1b2e7ec84a1ef73453ca86537d8' (2023-09-30)
  → 'github:lnl7/nix-darwin/8b6ea26d5d2e8359d06278364f41fbc4b903b28a' (2023-10-03)
• Updated input 'flake-compat':
    'github:edolstra/flake-compat/4f910c9827911b1ec2bf26b5a062cd09f8d89f85' (2023-10-02)
  → 'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30' (2023-10-01)
  → 'github:nix-community/home-manager/6bba64781e4b7c1f91a733583defbd3e46b49408' (2023-10-10)
• Updated input 'neovim-flake':
    'github:neovim/neovim/09a17f91d0d362c6e58bfdbe3ccdeacffb0b44b9?dir=contrib' (2023-10-02)
  → 'github:neovim/neovim/c3d21ad1bccd9a2975be73b1115213fd884eada3?dir=contrib' (2023-10-10)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/f5892ddac112a1e9b3612c39af1b72987ee5783a' (2023-09-29)
  → 'github:nixos/nixpkgs/87828a0e03d1418e848d3dd3f3014a632e4a4f64' (2023-10-06)
• Updated input 'nur':
    'github:nix-community/nur/94a47cbec5838634516641c5520b94ed62215111' (2023-10-02)
  → 'github:nix-community/nur/4f04090f1d14f608eb7c3f4205001e88c33590a3' (2023-10-10)
• Updated input 'nushell-src':
    'github:nushell/nushell/783f2a93423e1b5b4297682c54bd79c1de6dc547' (2023-10-02)
  → 'github:nushell/nushell/8c36e9df44ca483a3d3b07264c189155903681a5' (2023-10-10)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`94a47cbe` ➡️ `4f04090f`](https://github.com/nix-community/nur/compare/94a47cbec5838634516641c5520b94ed62215111...4f04090f1d14f608eb7c3f4205001e88c33590a3) <sub>(2023-10-02 to 2023-10-10)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`792c2e01` ➡️ `8b6ea26d`](https://github.com/lnl7/nix-darwin/compare/792c2e01347cb1b2e7ec84a1ef73453ca86537d8...8b6ea26d5d2e8359d06278364f41fbc4b903b28a) <sub>(2023-09-30 to 2023-10-03)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`f5892dda` ➡️ `87828a0e`](https://github.com/nixos/nixpkgs/compare/f5892ddac112a1e9b3612c39af1b72987ee5783a...87828a0e03d1418e848d3dd3f3014a632e4a4f64) <sub>(2023-09-29 to 2023-10-06)</sub>
 - Updated input [`flake-compat`](https://github.com/edolstra/flake-compat): [`4f910c98` ➡️ `0f9255e0`](https://github.com/edolstra/flake-compat/compare/4f910c9827911b1ec2bf26b5a062cd09f8d89f85...0f9255e01c2351cc7d116c072cb317785dd33b33) <sub>(2023-10-02 to 2023-10-04)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`09a17f91` ➡️ `c3d21ad1`](https://github.com/neovim/neovim/compare/09a17f91d0d362c6e58bfdbe3ccdeacffb0b44b9...c3d21ad1bccd9a2975be73b1115213fd884eada3) <sub>(2023-10-02 to 2023-10-10)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`6f9b5b83` ➡️ `6bba6478`](https://github.com/nix-community/home-manager/compare/6f9b5b83ad1f470b3d11b8a9fe1d5ef68c7d0e30...6bba64781e4b7c1f91a733583defbd3e46b49408) <sub>(2023-10-01 to 2023-10-10)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`783f2a93` ➡️ `8c36e9df`](https://github.com/nushell/nushell/compare/783f2a93423e1b5b4297682c54bd79c1de6dc547...8c36e9df44ca483a3d3b07264c189155903681a5) <sub>(2023-10-02 to 2023-10-10)</sub>