### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696360011,
-        "narHash": "sha256-HpPv27qMuPou4acXcZ8Klm7Zt0Elv9dgDvSJaomWb9Y=",
+        "lastModified": 1698429334,
+        "narHash": "sha256-Gq3+QabboczSu7RMpcy79RSLMSqnySO3wsnHQk4DfbE=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8b6ea26d5d2e8359d06278364f41fbc4b903b28a",
+        "rev": "afe83cbc2e673b1f08d32dd0f70df599678ff1e7",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696940889,
-        "narHash": "sha256-p2Wic74A1tZpFcld1wSEbFQQbrZ/tPDuLieCnspamQo=",
+        "lastModified": 1698795315,
+        "narHash": "sha256-fF5ScAWLMHXOuqsbLSG137kS1D+gr9JPtm4H2c4yBbU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6bba64781e4b7c1f91a733583defbd3e46b49408",
+        "rev": "9bc7d84b8213255ecd5eb6299afdb77c36ece71d",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1696958432,
-        "narHash": "sha256-yPhORnQjwEFGEswA5Y6bzF6iM0fgje1MLggyVDSz6Io=",
+        "lastModified": 1698765225,
+        "narHash": "sha256-K30xCGRbmKYj+NY7O0lvsPGctVp6shfQs61BAVq0Plc=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "c3d21ad1bccd9a2975be73b1115213fd884eada3",
+        "rev": "746a153bc1a1bc1433a1246fcf454eeb058b9de1",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696604326,
-        "narHash": "sha256-YXUNI0kLEcI5g8lqGMb0nh67fY9f2YoJsILafh6zlMo=",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "87828a0e03d1418e848d3dd3f3014a632e4a4f64",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1696957813,
-        "narHash": "sha256-01MpPV+9dfB+wlsPOKdfjpZ6ybtwNtEafjvmNISiYpY=",
+        "lastModified": 1698795974,
+        "narHash": "sha256-1CZZY3nvgo46hdSP9Z+0PDvPpTOuaDh6xfKldZGgJ3M=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "4f04090f1d14f608eb7c3f4205001e88c33590a3",
+        "rev": "4cf69a3615da6869af93d17f784404f821a7d7b1",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1696961144,
-        "narHash": "sha256-wrRQfdH7aH6Q17gI+zsWPQaX9LVlekkC2sHpPauVrrU=",
+        "lastModified": 1698778020,
+        "narHash": "sha256-bYCa1sZNwy3eHOksBvZZC5SYa48YdA/ToqfkUXtI9r8=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "8c36e9df44ca483a3d3b07264c189155903681a5",
+        "rev": "15c22db8f49d42cba97dc5f4bc1de24ac8c4587b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/8b6ea26d5d2e8359d06278364f41fbc4b903b28a' (2023-10-03)
  → 'github:lnl7/nix-darwin/afe83cbc2e673b1f08d32dd0f70df599678ff1e7' (2023-10-27)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6bba64781e4b7c1f91a733583defbd3e46b49408' (2023-10-10)
  → 'github:nix-community/home-manager/9bc7d84b8213255ecd5eb6299afdb77c36ece71d' (2023-10-31)
• Updated input 'neovim-flake':
    'github:neovim/neovim/c3d21ad1bccd9a2975be73b1115213fd884eada3?dir=contrib' (2023-10-10)
  → 'github:neovim/neovim/746a153bc1a1bc1433a1246fcf454eeb058b9de1?dir=contrib' (2023-10-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/87828a0e03d1418e848d3dd3f3014a632e4a4f64' (2023-10-06)
  → 'github:nixos/nixpkgs/0cbe9f69c234a7700596e943bfae7ef27a31b735' (2023-10-29)
• Updated input 'nur':
    'github:nix-community/nur/4f04090f1d14f608eb7c3f4205001e88c33590a3' (2023-10-10)
  → 'github:nix-community/nur/4cf69a3615da6869af93d17f784404f821a7d7b1' (2023-10-31)
• Updated input 'nushell-src':
    'github:nushell/nushell/8c36e9df44ca483a3d3b07264c189155903681a5' (2023-10-10)
  → 'github:nushell/nushell/15c22db8f49d42cba97dc5f4bc1de24ac8c4587b' (2023-10-31)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`4f04090f` ➡️ `4cf69a36`](https://github.com/nix-community/nur/compare/4f04090f1d14f608eb7c3f4205001e88c33590a3...4cf69a3615da6869af93d17f784404f821a7d7b1) <sub>(2023-10-10 to 2023-10-31)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`8b6ea26d` ➡️ `afe83cbc`](https://github.com/lnl7/nix-darwin/compare/8b6ea26d5d2e8359d06278364f41fbc4b903b28a...afe83cbc2e673b1f08d32dd0f70df599678ff1e7) <sub>(2023-10-03 to 2023-10-27)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`87828a0e` ➡️ `0cbe9f69`](https://github.com/nixos/nixpkgs/compare/87828a0e03d1418e848d3dd3f3014a632e4a4f64...0cbe9f69c234a7700596e943bfae7ef27a31b735) <sub>(2023-10-06 to 2023-10-29)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`c3d21ad1` ➡️ `746a153b`](https://github.com/neovim/neovim/compare/c3d21ad1bccd9a2975be73b1115213fd884eada3...746a153bc1a1bc1433a1246fcf454eeb058b9de1) <sub>(2023-10-10 to 2023-10-31)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`6bba6478` ➡️ `9bc7d84b`](https://github.com/nix-community/home-manager/compare/6bba64781e4b7c1f91a733583defbd3e46b49408...9bc7d84b8213255ecd5eb6299afdb77c36ece71d) <sub>(2023-10-10 to 2023-10-31)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`8c36e9df` ➡️ `15c22db8`](https://github.com/nushell/nushell/compare/8c36e9df44ca483a3d3b07264c189155903681a5...15c22db8f49d42cba97dc5f4bc1de24ac8c4587b) <sub>(2023-10-10 to 2023-10-31)</sub>