### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698429334,
-        "narHash": "sha256-Gq3+QabboczSu7RMpcy79RSLMSqnySO3wsnHQk4DfbE=",
+        "lastModified": 1699704228,
+        "narHash": "sha256-NApWG385goidsXmsakWgFRjvbH+aw/n1CGGHn/UuXsc=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "afe83cbc2e673b1f08d32dd0f70df599678ff1e7",
+        "rev": "0f1ad801387445fdda01d080db8ecf169be8e793",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698795315,
-        "narHash": "sha256-fF5ScAWLMHXOuqsbLSG137kS1D+gr9JPtm4H2c4yBbU=",
+        "lastModified": 1699783872,
+        "narHash": "sha256-4zTwLT2LL45Nmo6iwKB3ls3hWodVP9DiSWxki/oewWE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9bc7d84b8213255ecd5eb6299afdb77c36ece71d",
+        "rev": "280721186ab75a76537713ec310306f0eba3e407",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1698765225,
-        "narHash": "sha256-K30xCGRbmKYj+NY7O0lvsPGctVp6shfQs61BAVq0Plc=",
+        "lastModified": 1699845842,
+        "narHash": "sha256-zQNSUWW4w+W/YQ/CQge9piraodKiFCLoO8Lr+67fFoI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "746a153bc1a1bc1433a1246fcf454eeb058b9de1",
+        "rev": "d3582e102b7bd53afb58efb37eca866ec528dfbe",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698611440,
-        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "lastModified": 1699099776,
+        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1698795974,
-        "narHash": "sha256-1CZZY3nvgo46hdSP9Z+0PDvPpTOuaDh6xfKldZGgJ3M=",
+        "lastModified": 1699847092,
+        "narHash": "sha256-UuAJYOng3e0uXQeJ8JR2rqZT65ePceKQk69L0nOs95o=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "4cf69a3615da6869af93d17f784404f821a7d7b1",
+        "rev": "d28a36dfcaf81417cc4025965e404a4adb98a107",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1698778020,
-        "narHash": "sha256-bYCa1sZNwy3eHOksBvZZC5SYa48YdA/ToqfkUXtI9r8=",
+        "lastModified": 1699740213,
+        "narHash": "sha256-0DmHaYPIa0va3o+vxg4Q4zVJt5zU0cxTzgkG7oVa6Q4=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "15c22db8f49d42cba97dc5f4bc1de24ac8c4587b",
+        "rev": "0b253851097ddc673a1ae1eedead4d7e7c386899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/afe83cbc2e673b1f08d32dd0f70df599678ff1e7' (2023-10-27)
  → 'github:lnl7/nix-darwin/0f1ad801387445fdda01d080db8ecf169be8e793' (2023-11-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/9bc7d84b8213255ecd5eb6299afdb77c36ece71d' (2023-10-31)
  → 'github:nix-community/home-manager/280721186ab75a76537713ec310306f0eba3e407' (2023-11-12)
• Updated input 'neovim-flake':
    'github:neovim/neovim/746a153bc1a1bc1433a1246fcf454eeb058b9de1?dir=contrib' (2023-10-31)
  → 'github:neovim/neovim/d3582e102b7bd53afb58efb37eca866ec528dfbe?dir=contrib' (2023-11-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0cbe9f69c234a7700596e943bfae7ef27a31b735' (2023-10-29)
  → 'github:nixos/nixpkgs/85f1ba3e51676fa8cc604a3d863d729026a6b8eb' (2023-11-04)
• Updated input 'nur':
    'github:nix-community/nur/4cf69a3615da6869af93d17f784404f821a7d7b1' (2023-10-31)
  → 'github:nix-community/nur/d28a36dfcaf81417cc4025965e404a4adb98a107' (2023-11-13)
• Updated input 'nushell-src':
    'github:nushell/nushell/15c22db8f49d42cba97dc5f4bc1de24ac8c4587b' (2023-10-31)
  → 'github:nushell/nushell/0b253851097ddc673a1ae1eedead4d7e7c386899' (2023-11-11)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`4cf69a36` ➡️ `d28a36df`](https://github.com/nix-community/nur/compare/4cf69a3615da6869af93d17f784404f821a7d7b1...d28a36dfcaf81417cc4025965e404a4adb98a107) <sub>(2023-10-31 to 2023-11-13)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`afe83cbc` ➡️ `0f1ad801`](https://github.com/lnl7/nix-darwin/compare/afe83cbc2e673b1f08d32dd0f70df599678ff1e7...0f1ad801387445fdda01d080db8ecf169be8e793) <sub>(2023-10-27 to 2023-11-11)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`0cbe9f69` ➡️ `85f1ba3e`](https://github.com/nixos/nixpkgs/compare/0cbe9f69c234a7700596e943bfae7ef27a31b735...85f1ba3e51676fa8cc604a3d863d729026a6b8eb) <sub>(2023-10-29 to 2023-11-04)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`746a153b` ➡️ `d3582e10`](https://github.com/neovim/neovim/compare/746a153bc1a1bc1433a1246fcf454eeb058b9de1...d3582e102b7bd53afb58efb37eca866ec528dfbe) <sub>(2023-10-31 to 2023-11-13)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`9bc7d84b` ➡️ `28072118`](https://github.com/nix-community/home-manager/compare/9bc7d84b8213255ecd5eb6299afdb77c36ece71d...280721186ab75a76537713ec310306f0eba3e407) <sub>(2023-10-31 to 2023-11-12)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`15c22db8` ➡️ `0b253851`](https://github.com/nushell/nushell/compare/15c22db8f49d42cba97dc5f4bc1de24ac8c4587b...0b253851097ddc673a1ae1eedead4d7e7c386899) <sub>(2023-10-31 to 2023-11-11)</sub>