### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699704228,
-        "narHash": "sha256-NApWG385goidsXmsakWgFRjvbH+aw/n1CGGHn/UuXsc=",
+        "lastModified": 1699867978,
+        "narHash": "sha256-+arl45HUOcBdKiRGrKXZYXDyBQ6MQGkYPZa/28f6Yzo=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "0f1ad801387445fdda01d080db8ecf169be8e793",
+        "rev": "e67f2bf515343da378c3f82f098df8ca01bccc5f",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1699845842,
-        "narHash": "sha256-zQNSUWW4w+W/YQ/CQge9piraodKiFCLoO8Lr+67fFoI=",
+        "lastModified": 1700002977,
+        "narHash": "sha256-kpE1YDFRDJf/SVMaVqKlvuPqApsm11t72F4hGc9Gifs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "d3582e102b7bd53afb58efb37eca866ec528dfbe",
+        "rev": "ba58c6f8a44c9c37e97fce1d802dc5b5defceb3d",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699099776,
-        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
+        "lastModified": 1699781429,
+        "narHash": "sha256-UYefjidASiLORAjIvVsUHG6WBtRhM67kTjEY4XfZOFs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
+        "rev": "e44462d6021bfe23dfb24b775cc7c390844f773d",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1699847092,
-        "narHash": "sha256-UuAJYOng3e0uXQeJ8JR2rqZT65ePceKQk69L0nOs95o=",
+        "lastModified": 1700006713,
+        "narHash": "sha256-QS4+ucpbAoWPbAm/KGjZuywhGWrUS8uNi4JQbA7w4s8=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "d28a36dfcaf81417cc4025965e404a4adb98a107",
+        "rev": "379ce165f440e97d36f66eb11d68b2ce61afdb1d",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1699740213,
-        "narHash": "sha256-0DmHaYPIa0va3o+vxg4Q4zVJt5zU0cxTzgkG7oVa6Q4=",
+        "lastModified": 1699992079,
+        "narHash": "sha256-anIkIVRsJW2f2hj/Bz9lcw1vFoWhGHAE/XgIvnxbJg8=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "0b253851097ddc673a1ae1eedead4d7e7c386899",
+        "rev": "77a1c3c7b2f3a110d48bcb792968e6b0d85d4bb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/0f1ad801387445fdda01d080db8ecf169be8e793' (2023-11-11)
  → 'github:lnl7/nix-darwin/e67f2bf515343da378c3f82f098df8ca01bccc5f' (2023-11-13)
• Updated input 'neovim-flake':
    'github:neovim/neovim/d3582e102b7bd53afb58efb37eca866ec528dfbe?dir=contrib' (2023-11-13)
  → 'github:neovim/neovim/ba58c6f8a44c9c37e97fce1d802dc5b5defceb3d?dir=contrib' (2023-11-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/85f1ba3e51676fa8cc604a3d863d729026a6b8eb' (2023-11-04)
  → 'github:nixos/nixpkgs/e44462d6021bfe23dfb24b775cc7c390844f773d' (2023-11-12)
• Updated input 'nur':
    'github:nix-community/nur/d28a36dfcaf81417cc4025965e404a4adb98a107' (2023-11-13)
  → 'github:nix-community/nur/379ce165f440e97d36f66eb11d68b2ce61afdb1d' (2023-11-15)
• Updated input 'nushell-src':
    'github:nushell/nushell/0b253851097ddc673a1ae1eedead4d7e7c386899' (2023-11-11)
  → 'github:nushell/nushell/77a1c3c7b2f3a110d48bcb792968e6b0d85d4bb7' (2023-11-14)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`d28a36df` ➡️ `379ce165`](https://github.com/nix-community/nur/compare/d28a36dfcaf81417cc4025965e404a4adb98a107...379ce165f440e97d36f66eb11d68b2ce61afdb1d) <sub>(2023-11-13 to 2023-11-15)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`0f1ad801` ➡️ `e67f2bf5`](https://github.com/lnl7/nix-darwin/compare/0f1ad801387445fdda01d080db8ecf169be8e793...e67f2bf515343da378c3f82f098df8ca01bccc5f) <sub>(2023-11-11 to 2023-11-13)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`85f1ba3e` ➡️ `e44462d6`](https://github.com/nixos/nixpkgs/compare/85f1ba3e51676fa8cc604a3d863d729026a6b8eb...e44462d6021bfe23dfb24b775cc7c390844f773d) <sub>(2023-11-04 to 2023-11-12)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`d3582e10` ➡️ `ba58c6f8`](https://github.com/neovim/neovim/compare/d3582e102b7bd53afb58efb37eca866ec528dfbe...ba58c6f8a44c9c37e97fce1d802dc5b5defceb3d) <sub>(2023-11-13 to 2023-11-14)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`0b253851` ➡️ `77a1c3c7`](https://github.com/nushell/nushell/compare/0b253851097ddc673a1ae1eedead4d7e7c386899...77a1c3c7b2f3a110d48bcb792968e6b0d85d4bb7) <sub>(2023-11-11 to 2023-11-14)</sub>