### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699867978,
-        "narHash": "sha256-+arl45HUOcBdKiRGrKXZYXDyBQ6MQGkYPZa/28f6Yzo=",
+        "lastModified": 1700795494,
+        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "e67f2bf515343da378c3f82f098df8ca01bccc5f",
+        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699783872,
-        "narHash": "sha256-4zTwLT2LL45Nmo6iwKB3ls3hWodVP9DiSWxki/oewWE=",
+        "lastModified": 1702538064,
+        "narHash": "sha256-At5GwJPu2tzvS9dllhBoZmqK6lkkh/sOp2YefWRlaL8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "280721186ab75a76537713ec310306f0eba3e407",
+        "rev": "0e2e443ff24f9d75925e91b89d1da44b863734af",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1700002977,
-        "narHash": "sha256-kpE1YDFRDJf/SVMaVqKlvuPqApsm11t72F4hGc9Gifs=",
+        "lastModified": 1702595978,
+        "narHash": "sha256-PvcPk+f9ENeY5Jq1nvWpkL12KWeVQFhqQ2a8PLNfP/k=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "ba58c6f8a44c9c37e97fce1d802dc5b5defceb3d",
+        "rev": "f31f260f0c6449dba4c84071be6bfe91d3cb4993",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699781429,
-        "narHash": "sha256-UYefjidASiLORAjIvVsUHG6WBtRhM67kTjEY4XfZOFs=",
+        "lastModified": 1702312524,
+        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e44462d6021bfe23dfb24b775cc7c390844f773d",
+        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700006713,
-        "narHash": "sha256-QS4+ucpbAoWPbAm/KGjZuywhGWrUS8uNi4JQbA7w4s8=",
+        "lastModified": 1702599384,
+        "narHash": "sha256-W39mE6STcvX6k30xzk4/DGLajrYVEtp6SIOgzN4fDHo=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "379ce165f440e97d36f66eb11d68b2ce61afdb1d",
+        "rev": "8cf518b0011e34505344cc78732a977d1d4ea453",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1699992079,
-        "narHash": "sha256-anIkIVRsJW2f2hj/Bz9lcw1vFoWhGHAE/XgIvnxbJg8=",
+        "lastModified": 1702583748,
+        "narHash": "sha256-EfEW7Th5hJ5tuUW12ajAT3lhaPxgMASRi0OkxoxFwR4=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "77a1c3c7b2f3a110d48bcb792968e6b0d85d4bb7",
+        "rev": "c2b684464f7aac2cb6c1dc56c1f5704c38f7ac7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/e67f2bf515343da378c3f82f098df8ca01bccc5f' (2023-11-13)
  → 'github:lnl7/nix-darwin/4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d' (2023-11-24)
• Updated input 'home-manager':
    'github:nix-community/home-manager/280721186ab75a76537713ec310306f0eba3e407' (2023-11-12)
  → 'github:nix-community/home-manager/0e2e443ff24f9d75925e91b89d1da44b863734af' (2023-12-14)
• Updated input 'neovim-flake':
    'github:neovim/neovim/ba58c6f8a44c9c37e97fce1d802dc5b5defceb3d?dir=contrib' (2023-11-14)
  → 'github:neovim/neovim/f31f260f0c6449dba4c84071be6bfe91d3cb4993?dir=contrib' (2023-12-14)
• Updated input 'neovim-flake/flake-utils':
    'github:numtide/flake-utils/a1720a10a6cfe8234c0e93907ffe81be440f4cef' (2023-05-31)
  → 'github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384' (2023-09-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e44462d6021bfe23dfb24b775cc7c390844f773d' (2023-11-12)
  → 'github:nixos/nixpkgs/a9bf124c46ef298113270b1f84a164865987a91c' (2023-12-11)
• Updated input 'nur':
    'github:nix-community/nur/379ce165f440e97d36f66eb11d68b2ce61afdb1d' (2023-11-15)
  → 'github:nix-community/nur/8cf518b0011e34505344cc78732a977d1d4ea453' (2023-12-15)
• Updated input 'nushell-src':
    'github:nushell/nushell/77a1c3c7b2f3a110d48bcb792968e6b0d85d4bb7' (2023-11-14)
  → 'github:nushell/nushell/c2b684464f7aac2cb6c1dc56c1f5704c38f7ac7b' (2023-12-14)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`379ce165` ➡️ `8cf518b0`](https://github.com/nix-community/nur/compare/379ce165f440e97d36f66eb11d68b2ce61afdb1d...8cf518b0011e34505344cc78732a977d1d4ea453) <sub>(2023-11-15 to 2023-12-15)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`e67f2bf5` ➡️ `4b9b83d5`](https://github.com/lnl7/nix-darwin/compare/e67f2bf515343da378c3f82f098df8ca01bccc5f...4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d) <sub>(2023-11-13 to 2023-11-24)</sub>
 - Updated input [`neovim-flake/flake-utils`](https://github.com/numtide/flake-utils): [`a1720a10` ➡️ `ff7b65b4`](https://github.com/numtide/flake-utils/compare/a1720a10a6cfe8234c0e93907ffe81be440f4cef...ff7b65b44d01cf9ba6a71320833626af21126384) <sub>(2023-05-31 to 2023-09-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`e44462d6` ➡️ `a9bf124c`](https://github.com/nixos/nixpkgs/compare/e44462d6021bfe23dfb24b775cc7c390844f773d...a9bf124c46ef298113270b1f84a164865987a91c) <sub>(2023-11-12 to 2023-12-11)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`ba58c6f8` ➡️ `f31f260f`](https://github.com/neovim/neovim/compare/ba58c6f8a44c9c37e97fce1d802dc5b5defceb3d...f31f260f0c6449dba4c84071be6bfe91d3cb4993) <sub>(2023-11-14 to 2023-12-14)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`28072118` ➡️ `0e2e443f`](https://github.com/nix-community/home-manager/compare/280721186ab75a76537713ec310306f0eba3e407...0e2e443ff24f9d75925e91b89d1da44b863734af) <sub>(2023-11-12 to 2023-12-14)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`77a1c3c7` ➡️ `c2b68446`](https://github.com/nushell/nushell/compare/77a1c3c7b2f3a110d48bcb792968e6b0d85d4bb7...c2b684464f7aac2cb6c1dc56c1f5704c38f7ac7b) <sub>(2023-11-14 to 2023-12-14)</sub>