### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700795494,
-        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
+        "lastModified": 1703990467,
+        "narHash": "sha256-LItEeQVwDfLnavNskwdfRnonbEdq8DYiJlWRtF+bwng=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
+        "rev": "1a41453cba42a3a1af2fff003be455ddbd75386c",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702538064,
-        "narHash": "sha256-At5GwJPu2tzvS9dllhBoZmqK6lkkh/sOp2YefWRlaL8=",
+        "lastModified": 1703995158,
+        "narHash": "sha256-oYMwbObpWheGeeNWY1LjO/+omrbAWDNdyzNDxTr2jo8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0e2e443ff24f9d75925e91b89d1da44b863734af",
+        "rev": "2e8634c252890cb38c60ab996af04926537cbc27",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1702595978,
-        "narHash": "sha256-PvcPk+f9ENeY5Jq1nvWpkL12KWeVQFhqQ2a8PLNfP/k=",
+        "lastModified": 1704031853,
+        "narHash": "sha256-DOxfnhrIdTDWb+b9vKiuXq7zGTIhzC4g0EEP1uh36xs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "f31f260f0c6449dba4c84071be6bfe91d3cb4993",
+        "rev": "6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702312524,
-        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
+        "lastModified": 1703637592,
+        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
+        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702599384,
-        "narHash": "sha256-W39mE6STcvX6k30xzk4/DGLajrYVEtp6SIOgzN4fDHo=",
+        "lastModified": 1704071022,
+        "narHash": "sha256-ic6sbZYW/I3bNHLdOFmOip0+/nKAEptP2z5cZ5dLUhI=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "8cf518b0011e34505344cc78732a977d1d4ea453",
+        "rev": "fbb8789b92dce8870606027d97b0074435d91ffc",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1702583748,
-        "narHash": "sha256-EfEW7Th5hJ5tuUW12ajAT3lhaPxgMASRi0OkxoxFwR4=",
+        "lastModified": 1704033905,
+        "narHash": "sha256-krJAQhZmPxYP9VFiRQtFG8jBooMFdIGIzYfuoVAp7XA=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "c2b684464f7aac2cb6c1dc56c1f5704c38f7ac7b",
+        "rev": "de5ad5de19affee3986661da6dd888a2e12a813f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d' (2023-11-24)
  → 'github:lnl7/nix-darwin/1a41453cba42a3a1af2fff003be455ddbd75386c' (2023-12-31)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0e2e443ff24f9d75925e91b89d1da44b863734af' (2023-12-14)
  → 'github:nix-community/home-manager/2e8634c252890cb38c60ab996af04926537cbc27' (2023-12-31)
• Updated input 'neovim-flake':
    'github:neovim/neovim/f31f260f0c6449dba4c84071be6bfe91d3cb4993?dir=contrib' (2023-12-14)
  → 'github:neovim/neovim/6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac?dir=contrib' (2023-12-31)
• Updated input 'neovim-flake/flake-utils':
    'github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384' (2023-09-12)
  → 'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725' (2023-12-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a9bf124c46ef298113270b1f84a164865987a91c' (2023-12-11)
  → 'github:nixos/nixpkgs/cfc3698c31b1fb9cdcf10f36c9643460264d0ca8' (2023-12-27)
• Updated input 'nur':
    'github:nix-community/nur/8cf518b0011e34505344cc78732a977d1d4ea453' (2023-12-15)
  → 'github:nix-community/nur/fbb8789b92dce8870606027d97b0074435d91ffc' (2024-01-01)
• Updated input 'nushell-src':
    'github:nushell/nushell/c2b684464f7aac2cb6c1dc56c1f5704c38f7ac7b' (2023-12-14)
  → 'github:nushell/nushell/de5ad5de19affee3986661da6dd888a2e12a813f' (2023-12-31)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`8cf518b0` ➡️ `fbb8789b`](https://github.com/nix-community/nur/compare/8cf518b0011e34505344cc78732a977d1d4ea453...fbb8789b92dce8870606027d97b0074435d91ffc) <sub>(2023-12-15 to 2024-01-01)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`4b9b83d5` ➡️ `1a41453c`](https://github.com/lnl7/nix-darwin/compare/4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d...1a41453cba42a3a1af2fff003be455ddbd75386c) <sub>(2023-11-24 to 2023-12-31)</sub>
 - Updated input [`neovim-flake/flake-utils`](https://github.com/numtide/flake-utils): [`ff7b65b4` ➡️ `4022d587`](https://github.com/numtide/flake-utils/compare/ff7b65b44d01cf9ba6a71320833626af21126384...4022d587cbbfd70fe950c1e2083a02621806a725) <sub>(2023-09-12 to 2023-12-04)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`a9bf124c` ➡️ `cfc3698c`](https://github.com/nixos/nixpkgs/compare/a9bf124c46ef298113270b1f84a164865987a91c...cfc3698c31b1fb9cdcf10f36c9643460264d0ca8) <sub>(2023-12-11 to 2023-12-27)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`f31f260f` ➡️ `6fa0f303`](https://github.com/neovim/neovim/compare/f31f260f0c6449dba4c84071be6bfe91d3cb4993...6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac) <sub>(2023-12-14 to 2023-12-31)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`0e2e443f` ➡️ `2e8634c2`](https://github.com/nix-community/home-manager/compare/0e2e443ff24f9d75925e91b89d1da44b863734af...2e8634c252890cb38c60ab996af04926537cbc27) <sub>(2023-12-14 to 2023-12-31)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`c2b68446` ➡️ `de5ad5de`](https://github.com/nushell/nushell/compare/c2b684464f7aac2cb6c1dc56c1f5704c38f7ac7b...de5ad5de19affee3986661da6dd888a2e12a813f) <sub>(2023-12-14 to 2023-12-31)</sub>