### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703990467,
-        "narHash": "sha256-LItEeQVwDfLnavNskwdfRnonbEdq8DYiJlWRtF+bwng=",
+        "lastModified": 1707707289,
+        "narHash": "sha256-YuDt/eSTXMEHv8jS8BEZJgqCcG8Tr3cyqaZjJFXZHsw=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "1a41453cba42a3a1af2fff003be455ddbd75386c",
+        "rev": "44f50a5ecaab72a61d5fd8e5c5717bc4bf9c25dd",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703995158,
-        "narHash": "sha256-oYMwbObpWheGeeNWY1LjO/+omrbAWDNdyzNDxTr2jo8=",
+        "lastModified": 1707919853,
+        "narHash": "sha256-qxmBGDzutuJ/tsX4gp+Mr7fjxOZBbeT9ixhS5o4iFOw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e8634c252890cb38c60ab996af04926537cbc27",
+        "rev": "043ba285c6dc20f36441d48525402bcb9743c498",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1704031853,
-        "narHash": "sha256-DOxfnhrIdTDWb+b9vKiuXq7zGTIhzC4g0EEP1uh36xs=",
+        "lastModified": 1707941489,
+        "narHash": "sha256-S5KG+iYMFVHIEfeXSWYei2jcHs6kOfhM1pUoVQ9G/Lw=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac",
+        "rev": "d09957e0a06f350443c750d9838b5f1016c0cccc",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1706182238,
-        "narHash": "sha256-Ti7CerGydU7xyrP/ow85lHsOpf+XMx98kQnPoQCSi1g=",
+        "lastModified": 1707842204,
+        "narHash": "sha256-M+HAq1qWQBi/gywaMZwX0odU+Qb/XeqVeANGKRBDOwU=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "f84eaffc35d1a655e84749228cde19922fcf55f1",
+        "rev": "f1b2f71c86a5b1941d20608db0b1e88a07d31303",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703637592,
-        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
+        "lastModified": 1707689078,
+        "narHash": "sha256-UUGmRa84ZJHpGZ1WZEBEUOzaPOWG8LZ0yPg1pdDF/yM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
+        "rev": "f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704071022,
-        "narHash": "sha256-ic6sbZYW/I3bNHLdOFmOip0+/nKAEptP2z5cZ5dLUhI=",
+        "lastModified": 1707955948,
+        "narHash": "sha256-c6yXOnxO63cjm0D9PGkqLixqjkvKZxHVofpP1iNV/1s=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "fbb8789b92dce8870606027d97b0074435d91ffc",
+        "rev": "ef1f67d787f406be2be12afd7c10346c9c93d650",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1704033905,
-        "narHash": "sha256-krJAQhZmPxYP9VFiRQtFG8jBooMFdIGIzYfuoVAp7XA=",
+        "lastModified": 1707956100,
+        "narHash": "sha256-9dD2HjgmiiOQ+a61GD+7R55uHtPGWmtjl0xfLhdgtcs=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "de5ad5de19affee3986661da6dd888a2e12a813f",
+        "rev": "525acf9d9e3b049280ca531c123ee5610d6b966a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/1a41453cba42a3a1af2fff003be455ddbd75386c' (2023-12-31)
  → 'github:lnl7/nix-darwin/44f50a5ecaab72a61d5fd8e5c5717bc4bf9c25dd' (2024-02-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2e8634c252890cb38c60ab996af04926537cbc27' (2023-12-31)
  → 'github:nix-community/home-manager/043ba285c6dc20f36441d48525402bcb9743c498' (2024-02-14)
• Updated input 'neovim-flake':
    'github:neovim/neovim/6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac?dir=contrib' (2023-12-31)
  → 'github:neovim/neovim/d09957e0a06f350443c750d9838b5f1016c0cccc?dir=contrib' (2024-02-14)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/f84eaffc35d1a655e84749228cde19922fcf55f1' (2024-01-25)
  → 'github:nixos/nixos-hardware/f1b2f71c86a5b1941d20608db0b1e88a07d31303' (2024-02-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/cfc3698c31b1fb9cdcf10f36c9643460264d0ca8' (2023-12-27)
  → 'github:nixos/nixpkgs/f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8' (2024-02-11)
• Updated input 'nur':
    'github:nix-community/nur/fbb8789b92dce8870606027d97b0074435d91ffc' (2024-01-01)
  → 'github:nix-community/nur/ef1f67d787f406be2be12afd7c10346c9c93d650' (2024-02-15)
• Updated input 'nushell-src':
    'github:nushell/nushell/de5ad5de19affee3986661da6dd888a2e12a813f' (2023-12-31)
  → 'github:nushell/nushell/525acf9d9e3b049280ca531c123ee5610d6b966a' (2024-02-15)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`fbb8789b` ➡️ `ef1f67d7`](https://github.com/nix-community/nur/compare/fbb8789b92dce8870606027d97b0074435d91ffc...ef1f67d787f406be2be12afd7c10346c9c93d650) <sub>(2024-01-01 to 2024-02-15)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`1a41453c` ➡️ `44f50a5e`](https://github.com/lnl7/nix-darwin/compare/1a41453cba42a3a1af2fff003be455ddbd75386c...44f50a5ecaab72a61d5fd8e5c5717bc4bf9c25dd) <sub>(2023-12-31 to 2024-02-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`cfc3698c` ➡️ `f9d39fb9`](https://github.com/nixos/nixpkgs/compare/cfc3698c31b1fb9cdcf10f36c9643460264d0ca8...f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8) <sub>(2023-12-27 to 2024-02-11)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`6fa0f303` ➡️ `d09957e0`](https://github.com/neovim/neovim/compare/6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac...d09957e0a06f350443c750d9838b5f1016c0cccc) <sub>(2023-12-31 to 2024-02-14)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`2e8634c2` ➡️ `043ba285`](https://github.com/nix-community/home-manager/compare/2e8634c252890cb38c60ab996af04926537cbc27...043ba285c6dc20f36441d48525402bcb9743c498) <sub>(2023-12-31 to 2024-02-14)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`de5ad5de` ➡️ `525acf9d`](https://github.com/nushell/nushell/compare/de5ad5de19affee3986661da6dd888a2e12a813f...525acf9d9e3b049280ca531c123ee5610d6b966a) <sub>(2023-12-31 to 2024-02-15)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`f84eaffc` ➡️ `f1b2f71c`](https://github.com/nixos/nixos-hardware/compare/f84eaffc35d1a655e84749228cde19922fcf55f1...f1b2f71c86a5b1941d20608db0b1e88a07d31303) <sub>(2024-01-25 to 2024-02-13)</sub>