### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707707289,
-        "narHash": "sha256-YuDt/eSTXMEHv8jS8BEZJgqCcG8Tr3cyqaZjJFXZHsw=",
+        "lastModified": 1708737761,
+        "narHash": "sha256-sR/1cYjpgr71ZSrt6Kp5Dg4Ul3mo6pZIG400tuzYks8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "44f50a5ecaab72a61d5fd8e5c5717bc4bf9c25dd",
+        "rev": "bbde06bed1b72eddff063fa42f18644e90a0121e",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707919853,
-        "narHash": "sha256-qxmBGDzutuJ/tsX4gp+Mr7fjxOZBbeT9ixhS5o4iFOw=",
+        "lastModified": 1708806879,
+        "narHash": "sha256-MSbxtF3RThI8ANs/G4o1zIqF5/XlShHvwjl9Ws0QAbI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "043ba285c6dc20f36441d48525402bcb9743c498",
+        "rev": "4ee704cb13a5a7645436f400b9acc89a67b9c08a",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1707941489,
-        "narHash": "sha256-S5KG+iYMFVHIEfeXSWYei2jcHs6kOfhM1pUoVQ9G/Lw=",
+        "lastModified": 1708824117,
+        "narHash": "sha256-qP90K+UQLjtUz9fIzvpTK/YOhNGjwhy2Qen8Zee/Hdc=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "d09957e0a06f350443c750d9838b5f1016c0cccc",
+        "rev": "2e1f5055acdef650c27efc4afdf8606037ec021b",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1707842204,
-        "narHash": "sha256-M+HAq1qWQBi/gywaMZwX0odU+Qb/XeqVeANGKRBDOwU=",
+        "lastModified": 1708594753,
+        "narHash": "sha256-c/gH7iXS/IYH9NrFOT+aJqTq+iEBkvAkpWuUHGU3+f0=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "f1b2f71c86a5b1941d20608db0b1e88a07d31303",
+        "rev": "3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707689078,
-        "narHash": "sha256-UUGmRa84ZJHpGZ1WZEBEUOzaPOWG8LZ0yPg1pdDF/yM=",
+        "lastModified": 1708655239,
+        "narHash": "sha256-ZrP/yACUvDB+zbqYJsln4iwotbH6CTZiTkANJ0AgDv4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8",
+        "rev": "cbc4211f0afffe6dfd2478a62615dd5175a13f9a",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707955948,
-        "narHash": "sha256-c6yXOnxO63cjm0D9PGkqLixqjkvKZxHVofpP1iNV/1s=",
+        "lastModified": 1708831174,
+        "narHash": "sha256-qu6C+XHv7bVoBYlUCcqlqVWepffY4cdlpu0N129rcBw=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "ef1f67d787f406be2be12afd7c10346c9c93d650",
+        "rev": "9549d87f2cddc0579c67443e4ee6a95ea1da6380",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1707956100,
-        "narHash": "sha256-9dD2HjgmiiOQ+a61GD+7R55uHtPGWmtjl0xfLhdgtcs=",
+        "lastModified": 1708815768,
+        "narHash": "sha256-arWRUizHCSgw1v0Jrl45neXKMFy26rmkPgqQj4muMhQ=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "525acf9d9e3b049280ca531c123ee5610d6b966a",
+        "rev": "e09b4817e11496a168c4b22abe91db72079a016d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/44f50a5ecaab72a61d5fd8e5c5717bc4bf9c25dd' (2024-02-12)
  → 'github:lnl7/nix-darwin/bbde06bed1b72eddff063fa42f18644e90a0121e' (2024-02-24)
• Updated input 'home-manager':
    'github:nix-community/home-manager/043ba285c6dc20f36441d48525402bcb9743c498' (2024-02-14)
  → 'github:nix-community/home-manager/4ee704cb13a5a7645436f400b9acc89a67b9c08a' (2024-02-24)
• Updated input 'neovim-flake':
    'github:neovim/neovim/d09957e0a06f350443c750d9838b5f1016c0cccc?dir=contrib' (2024-02-14)
  → 'github:neovim/neovim/2e1f5055acdef650c27efc4afdf8606037ec021b?dir=contrib' (2024-02-25)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/f1b2f71c86a5b1941d20608db0b1e88a07d31303' (2024-02-13)
  → 'github:nixos/nixos-hardware/3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958' (2024-02-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8' (2024-02-11)
  → 'github:nixos/nixpkgs/cbc4211f0afffe6dfd2478a62615dd5175a13f9a' (2024-02-23)
• Updated input 'nur':
    'github:nix-community/nur/ef1f67d787f406be2be12afd7c10346c9c93d650' (2024-02-15)
  → 'github:nix-community/nur/9549d87f2cddc0579c67443e4ee6a95ea1da6380' (2024-02-25)
• Updated input 'nushell-src':
    'github:nushell/nushell/525acf9d9e3b049280ca531c123ee5610d6b966a' (2024-02-15)
  → 'github:nushell/nushell/e09b4817e11496a168c4b22abe91db72079a016d' (2024-02-24)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`ef1f67d7` ➡️ `9549d87f`](https://github.com/nix-community/nur/compare/ef1f67d787f406be2be12afd7c10346c9c93d650...9549d87f2cddc0579c67443e4ee6a95ea1da6380) <sub>(2024-02-15 to 2024-02-25)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`44f50a5e` ➡️ `bbde06be`](https://github.com/lnl7/nix-darwin/compare/44f50a5ecaab72a61d5fd8e5c5717bc4bf9c25dd...bbde06bed1b72eddff063fa42f18644e90a0121e) <sub>(2024-02-12 to 2024-02-24)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`f9d39fb9` ➡️ `cbc4211f`](https://github.com/nixos/nixpkgs/compare/f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8...cbc4211f0afffe6dfd2478a62615dd5175a13f9a) <sub>(2024-02-11 to 2024-02-23)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`d09957e0` ➡️ `2e1f5055`](https://github.com/neovim/neovim/compare/d09957e0a06f350443c750d9838b5f1016c0cccc...2e1f5055acdef650c27efc4afdf8606037ec021b) <sub>(2024-02-14 to 2024-02-25)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`043ba285` ➡️ `4ee704cb`](https://github.com/nix-community/home-manager/compare/043ba285c6dc20f36441d48525402bcb9743c498...4ee704cb13a5a7645436f400b9acc89a67b9c08a) <sub>(2024-02-14 to 2024-02-24)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`525acf9d` ➡️ `e09b4817`](https://github.com/nushell/nushell/compare/525acf9d9e3b049280ca531c123ee5610d6b966a...e09b4817e11496a168c4b22abe91db72079a016d) <sub>(2024-02-15 to 2024-02-24)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`f1b2f71c` ➡️ `3f7d0bca`](https://github.com/nixos/nixos-hardware/compare/f1b2f71c86a5b1941d20608db0b1e88a07d31303...3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958) <sub>(2024-02-13 to 2024-02-22)</sub>