### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703990467,
-        "narHash": "sha256-LItEeQVwDfLnavNskwdfRnonbEdq8DYiJlWRtF+bwng=",
+        "lastModified": 1708737761,
+        "narHash": "sha256-sR/1cYjpgr71ZSrt6Kp5Dg4Ul3mo6pZIG400tuzYks8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "1a41453cba42a3a1af2fff003be455ddbd75386c",
+        "rev": "bbde06bed1b72eddff063fa42f18644e90a0121e",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703995158,
-        "narHash": "sha256-oYMwbObpWheGeeNWY1LjO/+omrbAWDNdyzNDxTr2jo8=",
+        "lastModified": 1708806879,
+        "narHash": "sha256-MSbxtF3RThI8ANs/G4o1zIqF5/XlShHvwjl9Ws0QAbI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e8634c252890cb38c60ab996af04926537cbc27",
+        "rev": "4ee704cb13a5a7645436f400b9acc89a67b9c08a",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1704031853,
-        "narHash": "sha256-DOxfnhrIdTDWb+b9vKiuXq7zGTIhzC4g0EEP1uh36xs=",
+        "lastModified": 1708855537,
+        "narHash": "sha256-htGTw+AjwF89FrfEapUXBHDpjfY/FlVngsq7FrWb6VA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac",
+        "rev": "0fcbda59871ebc5fc91cac7fa430a4a93f6698c2",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1706182238,
-        "narHash": "sha256-Ti7CerGydU7xyrP/ow85lHsOpf+XMx98kQnPoQCSi1g=",
+        "lastModified": 1708594753,
+        "narHash": "sha256-c/gH7iXS/IYH9NrFOT+aJqTq+iEBkvAkpWuUHGU3+f0=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "f84eaffc35d1a655e84749228cde19922fcf55f1",
+        "rev": "3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703637592,
-        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
+        "lastModified": 1708807242,
+        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
+        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704071022,
-        "narHash": "sha256-ic6sbZYW/I3bNHLdOFmOip0+/nKAEptP2z5cZ5dLUhI=",
+        "lastModified": 1708864816,
+        "narHash": "sha256-SM1zlHhoZf20lhp0v7ss52MYEWux/j+jfqfxUp8yqW8=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "fbb8789b92dce8870606027d97b0074435d91ffc",
+        "rev": "1fe352ab8a7560c8bbd793852c52979894a7705e",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1704033905,
-        "narHash": "sha256-krJAQhZmPxYP9VFiRQtFG8jBooMFdIGIzYfuoVAp7XA=",
+        "lastModified": 1708815768,
+        "narHash": "sha256-arWRUizHCSgw1v0Jrl45neXKMFy26rmkPgqQj4muMhQ=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "de5ad5de19affee3986661da6dd888a2e12a813f",
+        "rev": "e09b4817e11496a168c4b22abe91db72079a016d",
         "type": "github"
       },
       "original": {

--- a/home/modules/app/obsidian.nix
+++ b/home/modules/app/obsidian.nix
@@ -3,14 +3,6 @@
 with lib;
 let
   cfg = config.nyx.modules.app.obsidian;
-  obsidian = lib.throwIf (lib.versionOlder "1.4.16" pkgs.obsidian.version) "Obsidian no longer requires EOL Electron" (
-    pkgs.obsidian.override {
-      electron = pkgs.electron_25.overrideAttrs (_: {
-        preFixup = "patchelf --add-needed ${pkgs.libglvnd}/lib/libEGL.so.1 $out/bin/electron"; # NixOS/nixpkgs#272912
-        meta.knownVulnerabilities = [ ]; # NixOS/nixpkgs#273611
-      });
-    }
-  );
 in
 {
   options.nyx.modules.app.obsidian = {
@@ -18,6 +10,6 @@ in
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ obsidian ];
+    home.packages = with pkgs; [ obsidian ];
   };
 }


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/1a41453cba42a3a1af2fff003be455ddbd75386c' (2023-12-31)
  → 'github:lnl7/nix-darwin/bbde06bed1b72eddff063fa42f18644e90a0121e' (2024-02-24)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2e8634c252890cb38c60ab996af04926537cbc27' (2023-12-31)
  → 'github:nix-community/home-manager/4ee704cb13a5a7645436f400b9acc89a67b9c08a' (2024-02-24)
• Updated input 'neovim-flake':
    'github:neovim/neovim/6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac?dir=contrib' (2023-12-31)
  → 'github:neovim/neovim/0fcbda59871ebc5fc91cac7fa430a4a93f6698c2?dir=contrib' (2024-02-25)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/f84eaffc35d1a655e84749228cde19922fcf55f1' (2024-01-25)
  → 'github:nixos/nixos-hardware/3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958' (2024-02-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/cfc3698c31b1fb9cdcf10f36c9643460264d0ca8' (2023-12-27)
  → 'github:nixos/nixpkgs/73de017ef2d18a04ac4bfd0c02650007ccb31c2a' (2024-02-24)
• Updated input 'nur':
    'github:nix-community/nur/fbb8789b92dce8870606027d97b0074435d91ffc' (2024-01-01)
  → 'github:nix-community/nur/1fe352ab8a7560c8bbd793852c52979894a7705e' (2024-02-25)
• Updated input 'nushell-src':
    'github:nushell/nushell/de5ad5de19affee3986661da6dd888a2e12a813f' (2023-12-31)
  → 'github:nushell/nushell/e09b4817e11496a168c4b22abe91db72079a016d' (2024-02-24)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`fbb8789b` ➡️ `1fe352ab`](https://github.com/nix-community/nur/compare/fbb8789b92dce8870606027d97b0074435d91ffc...1fe352ab8a7560c8bbd793852c52979894a7705e) <sub>(2024-01-01 to 2024-02-25)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`1a41453c` ➡️ `bbde06be`](https://github.com/lnl7/nix-darwin/compare/1a41453cba42a3a1af2fff003be455ddbd75386c...bbde06bed1b72eddff063fa42f18644e90a0121e) <sub>(2023-12-31 to 2024-02-24)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`cfc3698c` ➡️ `73de017e`](https://github.com/nixos/nixpkgs/compare/cfc3698c31b1fb9cdcf10f36c9643460264d0ca8...73de017ef2d18a04ac4bfd0c02650007ccb31c2a) <sub>(2023-12-27 to 2024-02-24)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`6fa0f303` ➡️ `0fcbda59`](https://github.com/neovim/neovim/compare/6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac...0fcbda59871ebc5fc91cac7fa430a4a93f6698c2) <sub>(2023-12-31 to 2024-02-25)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`2e8634c2` ➡️ `4ee704cb`](https://github.com/nix-community/home-manager/compare/2e8634c252890cb38c60ab996af04926537cbc27...4ee704cb13a5a7645436f400b9acc89a67b9c08a) <sub>(2023-12-31 to 2024-02-24)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`de5ad5de` ➡️ `e09b4817`](https://github.com/nushell/nushell/compare/de5ad5de19affee3986661da6dd888a2e12a813f...e09b4817e11496a168c4b22abe91db72079a016d) <sub>(2023-12-31 to 2024-02-24)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`f84eaffc` ➡️ `3f7d0bca`](https://github.com/nixos/nixos-hardware/compare/f84eaffc35d1a655e84749228cde19922fcf55f1...3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958) <sub>(2024-01-25 to 2024-02-22)</sub>