### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/config/.config/nvim/lua/eden/mod/lsp/init.lua
+++ b/config/.config/nvim/lua/eden/mod/lsp/init.lua
@@ -113,7 +113,6 @@ return {
           },
         },
         pyright = {},
-        rnix = {},
         vimls = {},
       }
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708737761,
-        "narHash": "sha256-sR/1cYjpgr71ZSrt6Kp5Dg4Ul3mo6pZIG400tuzYks8=",
+        "lastModified": 1711763326,
+        "narHash": "sha256-sXcesZWKXFlEQ8oyGHnfk4xc9f2Ip0X/+YZOq3sKviI=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "bbde06bed1b72eddff063fa42f18644e90a0121e",
+        "rev": "36524adc31566655f2f4d55ad6b875fb5c1a4083",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708806879,
-        "narHash": "sha256-MSbxtF3RThI8ANs/G4o1zIqF5/XlShHvwjl9Ws0QAbI=",
+        "lastModified": 1711915616,
+        "narHash": "sha256-co6LoFA+j6BZEeJNSR8nZ4oOort5qYPskjrDHBaJgmo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4ee704cb13a5a7645436f400b9acc89a67b9c08a",
+        "rev": "820be197ccf3adaad9a8856ef255c13b6cc561a6",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1708855537,
-        "narHash": "sha256-htGTw+AjwF89FrfEapUXBHDpjfY/FlVngsq7FrWb6VA=",
+        "lastModified": 1711929762,
+        "narHash": "sha256-Id+90kZA3TzxzmbAVIRAQv9g0a+2m1uSpUKa7QohbSs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "0fcbda59871ebc5fc91cac7fa430a4a93f6698c2",
+        "rev": "b8858dddbf7b7f1ee3033acfab3d6f54a0ed3114",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1708594753,
-        "narHash": "sha256-c/gH7iXS/IYH9NrFOT+aJqTq+iEBkvAkpWuUHGU3+f0=",
+        "lastModified": 1711352745,
+        "narHash": "sha256-luvqik+i3HTvCbXQZgB6uggvEcxI9uae0nmrgtXJ17U=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958",
+        "rev": "9a763a7acc4cfbb8603bb0231fec3eda864f81c0",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708807242,
-        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708864816,
-        "narHash": "sha256-SM1zlHhoZf20lhp0v7ss52MYEWux/j+jfqfxUp8yqW8=",
+        "lastModified": 1711914285,
+        "narHash": "sha256-n7Bm62/s+t/S3xiZz33gp4HWgKfSOgYG5JzmT0gJoQ8=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "1fe352ab8a7560c8bbd793852c52979894a7705e",
+        "rev": "327169ed2b4766f8112d4fb144bc8f8a7cebf8bd",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1708815768,
-        "narHash": "sha256-arWRUizHCSgw1v0Jrl45neXKMFy26rmkPgqQj4muMhQ=",
+        "lastModified": 1711842437,
+        "narHash": "sha256-jttg9UokZ9c1tLTj22e8BN620q4/qJHnGR32xHsb9+k=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "e09b4817e11496a168c4b22abe91db72079a016d",
+        "rev": "0cf7de598b2cbeba8fbe955baa0557de9d9df121",
         "type": "github"
       },
       "original": {

--- a/home/modules/shell/neovim.nix
+++ b/home/modules/shell/neovim.nix
@@ -34,7 +34,6 @@ in
         nodePackages.typescript-language-server
         nodePackages.vim-language-server
         nodePackages.write-good
-        rnix-lsp
       ] ++ optionals pkgs.stdenv.isLinux [
         omnisharp-roslyn
         lua-language-server

--- a/system/common/profiles/desktop.nix
+++ b/system/common/profiles/desktop.nix
@@ -11,7 +11,7 @@ in
 
   config = mkIf cfg.enable {
     fonts = {
-      fonts = with pkgs; [
+      packages = with pkgs; [
         (
           nerdfonts.override {
             fonts = [ "JetBrainsMono" "Hack" "Meslo" "UbuntuMono" ];

--- a/system/nixos/modules/yubikey/default.nix
+++ b/system/nixos/modules/yubikey/default.nix
@@ -8,10 +8,10 @@ in
   options.nyx.modules.yubikey = {
     enable = mkEnableOption "yubikey support";
     istty = mkEnableOption "Set pinentry to curses if no display";
-    pinentryFlavor = mkOption {
-      type = types.nullOr (types.enum pkgs.pinentry.flavors);
+    pinentryPackage = mkOption {
+      type = types.nullOr types.package;
       default = null;
-      description = "Pinentry Flavor";
+      description = "Pinentry Package";
     };
   };
 
@@ -24,7 +24,7 @@ in
     programs.gnupg.agent = {
       enable = true;
       enableSSHSupport = true;
-      pinentryFlavor = if cfg.pinentryFlavor != null then cfg.pinentryFlavor else if cfg.istty then "curses" else "qt";
+      pinentryPackage = cfg.pinentryPackage;
     };
     # environment.shellInit = ''
     #   export SSH_AUTH_SOCK="/run/user/$UID/gnupg/S.gpg-agent.ssh"

--- a/system/nixos/profiles/desktop/default.nix
+++ b/system/nixos/profiles/desktop/default.nix
@@ -23,6 +23,8 @@ in
   };
 
   config = mkIf cfg.enable {
+    nyx.modules.yubikey.pinentryPackage = pkgs.pinentry-qt;
+
     services.printing.enable = true;
 
     environment.systemPackages = with pkgs; [

--- a/system/nixos/profiles/desktop/default.nix
+++ b/system/nixos/profiles/desktop/default.nix
@@ -53,7 +53,7 @@ in
     # Desktop environment flavor
     services.xserver = {
       enable = true;
-      layout = "us";
+      xkb.layout = "us";
       libinput = mkIf cfg.laptop {
         enable = true;
         touchpad = {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/bbde06bed1b72eddff063fa42f18644e90a0121e' (2024-02-24)
  → 'github:lnl7/nix-darwin/36524adc31566655f2f4d55ad6b875fb5c1a4083' (2024-03-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/4ee704cb13a5a7645436f400b9acc89a67b9c08a' (2024-02-24)
  → 'github:nix-community/home-manager/820be197ccf3adaad9a8856ef255c13b6cc561a6' (2024-03-31)
• Updated input 'neovim-flake':
    'github:neovim/neovim/0fcbda59871ebc5fc91cac7fa430a4a93f6698c2?dir=contrib' (2024-02-25)
  → 'github:neovim/neovim/b8858dddbf7b7f1ee3033acfab3d6f54a0ed3114?dir=contrib' (2024-04-01)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958' (2024-02-22)
  → 'github:nixos/nixos-hardware/9a763a7acc4cfbb8603bb0231fec3eda864f81c0' (2024-03-25)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/73de017ef2d18a04ac4bfd0c02650007ccb31c2a' (2024-02-24)
  → 'github:nixos/nixpkgs/d8fe5e6c92d0d190646fb9f1056741a229980089' (2024-03-29)
• Updated input 'nur':
    'github:nix-community/nur/1fe352ab8a7560c8bbd793852c52979894a7705e' (2024-02-25)
  → 'github:nix-community/nur/327169ed2b4766f8112d4fb144bc8f8a7cebf8bd' (2024-03-31)
• Updated input 'nushell-src':
    'github:nushell/nushell/e09b4817e11496a168c4b22abe91db72079a016d' (2024-02-24)
  → 'github:nushell/nushell/0cf7de598b2cbeba8fbe955baa0557de9d9df121' (2024-03-30)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`1fe352ab` ➡️ `327169ed`](https://github.com/nix-community/nur/compare/1fe352ab8a7560c8bbd793852c52979894a7705e...327169ed2b4766f8112d4fb144bc8f8a7cebf8bd) <sub>(2024-02-25 to 2024-03-31)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`bbde06be` ➡️ `36524adc`](https://github.com/lnl7/nix-darwin/compare/bbde06bed1b72eddff063fa42f18644e90a0121e...36524adc31566655f2f4d55ad6b875fb5c1a4083) <sub>(2024-02-24 to 2024-03-30)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`73de017e` ➡️ `d8fe5e6c`](https://github.com/nixos/nixpkgs/compare/73de017ef2d18a04ac4bfd0c02650007ccb31c2a...d8fe5e6c92d0d190646fb9f1056741a229980089) <sub>(2024-02-24 to 2024-03-29)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`0fcbda59` ➡️ `b8858ddd`](https://github.com/neovim/neovim/compare/0fcbda59871ebc5fc91cac7fa430a4a93f6698c2...b8858dddbf7b7f1ee3033acfab3d6f54a0ed3114) <sub>(2024-02-25 to 2024-04-01)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`4ee704cb` ➡️ `820be197`](https://github.com/nix-community/home-manager/compare/4ee704cb13a5a7645436f400b9acc89a67b9c08a...820be197ccf3adaad9a8856ef255c13b6cc561a6) <sub>(2024-02-24 to 2024-03-31)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`e09b4817` ➡️ `0cf7de59`](https://github.com/nushell/nushell/compare/e09b4817e11496a168c4b22abe91db72079a016d...0cf7de598b2cbeba8fbe955baa0557de9d9df121) <sub>(2024-02-24 to 2024-03-30)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`3f7d0bca` ➡️ `9a763a7a`](https://github.com/nixos/nixos-hardware/compare/3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958...9a763a7acc4cfbb8603bb0231fec3eda864f81c0) <sub>(2024-02-22 to 2024-03-25)</sub>