### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711763326,
-        "narHash": "sha256-sXcesZWKXFlEQ8oyGHnfk4xc9f2Ip0X/+YZOq3sKviI=",
+        "lastModified": 1715653378,
+        "narHash": "sha256-6kbg/PI3+SBP17f4T0js3CBsMLVtlD0JqJhDKgzk1mQ=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "36524adc31566655f2f4d55ad6b875fb5c1a4083",
+        "rev": "de8b0d60d6fd34f35abffc46adc94ebaa6996ce2",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711915616,
-        "narHash": "sha256-co6LoFA+j6BZEeJNSR8nZ4oOort5qYPskjrDHBaJgmo=",
+        "lastModified": 1715486357,
+        "narHash": "sha256-4pRuzsHZOW5W4CsXI9uhKtiJeQSUoe1d2M9mWU98HC4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "820be197ccf3adaad9a8856ef255c13b6cc561a6",
+        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1711929762,
-        "narHash": "sha256-Id+90kZA3TzxzmbAVIRAQv9g0a+2m1uSpUKa7QohbSs=",
+        "lastModified": 1715728713,
+        "narHash": "sha256-DmODP02EhM3+O2hHKB+AVJc+5qykxDh8nz7POO6zGrI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "b8858dddbf7b7f1ee3033acfab3d6f54a0ed3114",
+        "rev": "7acf39ddab8ebdb63ebf78ec980149d20783fd4b",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1711352745,
-        "narHash": "sha256-luvqik+i3HTvCbXQZgB6uggvEcxI9uae0nmrgtXJ17U=",
+        "lastModified": 1715148395,
+        "narHash": "sha256-lRxjTxY3103LGMjWdVqntKZHhlmMX12QUjeFrQMmGaE=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "9a763a7acc4cfbb8603bb0231fec3eda864f81c0",
+        "rev": "a4e2b7909fc1bdf30c30ef21d388fde0b5cdde4a",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "lastModified": 1715534503,
+        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711914285,
-        "narHash": "sha256-n7Bm62/s+t/S3xiZz33gp4HWgKfSOgYG5JzmT0gJoQ8=",
+        "lastModified": 1715734413,
+        "narHash": "sha256-Lz3+ZcFDEaWr0mmtzpyB97+1HUNEpPzAKrQ+tkyQ2pw=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "327169ed2b4766f8112d4fb144bc8f8a7cebf8bd",
+        "rev": "f22bd00bafa23dcf421eac82a93b75433f8f053a",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1711842437,
-        "narHash": "sha256-jttg9UokZ9c1tLTj22e8BN620q4/qJHnGR32xHsb9+k=",
+        "lastModified": 1715721006,
+        "narHash": "sha256-zd649yjoM8oDPOBl3YMULO918l2+w1H0tQHc58pc20I=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "0cf7de598b2cbeba8fbe955baa0557de9d9df121",
+        "rev": "c3da44cbb727348411d3520bf2b186860496f8da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/36524adc31566655f2f4d55ad6b875fb5c1a4083' (2024-03-30)
  → 'github:lnl7/nix-darwin/de8b0d60d6fd34f35abffc46adc94ebaa6996ce2' (2024-05-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/820be197ccf3adaad9a8856ef255c13b6cc561a6' (2024-03-31)
  → 'github:nix-community/home-manager/44677a1c96810a8e8c4ffaeaad10c842402647c1' (2024-05-12)
• Updated input 'neovim-flake':
    'github:neovim/neovim/b8858dddbf7b7f1ee3033acfab3d6f54a0ed3114?dir=contrib' (2024-04-01)
  → 'github:neovim/neovim/7acf39ddab8ebdb63ebf78ec980149d20783fd4b?dir=contrib' (2024-05-14)
• Updated input 'neovim-flake/flake-utils':
    'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725' (2023-12-04)
  → 'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/9a763a7acc4cfbb8603bb0231fec3eda864f81c0' (2024-03-25)
  → 'github:nixos/nixos-hardware/a4e2b7909fc1bdf30c30ef21d388fde0b5cdde4a' (2024-05-08)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d8fe5e6c92d0d190646fb9f1056741a229980089' (2024-03-29)
  → 'github:nixos/nixpkgs/2057814051972fa1453ddfb0d98badbea9b83c06' (2024-05-12)
• Updated input 'nur':
    'github:nix-community/nur/327169ed2b4766f8112d4fb144bc8f8a7cebf8bd' (2024-03-31)
  → 'github:nix-community/nur/f22bd00bafa23dcf421eac82a93b75433f8f053a' (2024-05-15)
• Updated input 'nushell-src':
    'github:nushell/nushell/0cf7de598b2cbeba8fbe955baa0557de9d9df121' (2024-03-30)
  → 'github:nushell/nushell/c3da44cbb727348411d3520bf2b186860496f8da' (2024-05-14)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`327169ed` ➡️ `f22bd00b`](https://github.com/nix-community/nur/compare/327169ed2b4766f8112d4fb144bc8f8a7cebf8bd...f22bd00bafa23dcf421eac82a93b75433f8f053a) <sub>(2024-03-31 to 2024-05-15)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`36524adc` ➡️ `de8b0d60`](https://github.com/lnl7/nix-darwin/compare/36524adc31566655f2f4d55ad6b875fb5c1a4083...de8b0d60d6fd34f35abffc46adc94ebaa6996ce2) <sub>(2024-03-30 to 2024-05-14)</sub>
 - Updated input [`neovim-flake/flake-utils`](https://github.com/numtide/flake-utils): [`4022d587` ➡️ `b1d9ab70`](https://github.com/numtide/flake-utils/compare/4022d587cbbfd70fe950c1e2083a02621806a725...b1d9ab70662946ef0850d488da1c9019f3a9752a) <sub>(2023-12-04 to 2024-03-11)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`d8fe5e6c` ➡️ `20578140`](https://github.com/nixos/nixpkgs/compare/d8fe5e6c92d0d190646fb9f1056741a229980089...2057814051972fa1453ddfb0d98badbea9b83c06) <sub>(2024-03-29 to 2024-05-12)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`b8858ddd` ➡️ `7acf39dd`](https://github.com/neovim/neovim/compare/b8858dddbf7b7f1ee3033acfab3d6f54a0ed3114...7acf39ddab8ebdb63ebf78ec980149d20783fd4b) <sub>(2024-04-01 to 2024-05-14)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`820be197` ➡️ `44677a1c`](https://github.com/nix-community/home-manager/compare/820be197ccf3adaad9a8856ef255c13b6cc561a6...44677a1c96810a8e8c4ffaeaad10c842402647c1) <sub>(2024-03-31 to 2024-05-12)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`0cf7de59` ➡️ `c3da44cb`](https://github.com/nushell/nushell/compare/0cf7de598b2cbeba8fbe955baa0557de9d9df121...c3da44cbb727348411d3520bf2b186860496f8da) <sub>(2024-03-30 to 2024-05-14)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`9a763a7a` ➡️ `a4e2b790`](https://github.com/nixos/nixos-hardware/compare/9a763a7acc4cfbb8603bb0231fec3eda864f81c0...a4e2b7909fc1bdf30c30ef21d388fde0b5cdde4a) <sub>(2024-03-25 to 2024-05-08)</sub>