### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711763326,
-        "narHash": "sha256-sXcesZWKXFlEQ8oyGHnfk4xc9f2Ip0X/+YZOq3sKviI=",
+        "lastModified": 1716240091,
+        "narHash": "sha256-++gJuNv0X8naF1VkaO2sAiM3T4wLx1NtdfubEsRzX7U=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "36524adc31566655f2f4d55ad6b875fb5c1a4083",
+        "rev": "8bf083c992e2bc0a8c07f5860d3866739b698883",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711915616,
-        "narHash": "sha256-co6LoFA+j6BZEeJNSR8nZ4oOort5qYPskjrDHBaJgmo=",
+        "lastModified": 1715930644,
+        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "820be197ccf3adaad9a8856ef255c13b6cc561a6",
+        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1711929762,
-        "narHash": "sha256-Id+90kZA3TzxzmbAVIRAQv9g0a+2m1uSpUKa7QohbSs=",
+        "lastModified": 1716248759,
+        "narHash": "sha256-9B1kGawSyC5LUiY+6aMwoeAprrVT2UXLQ6KeU/Is4aQ=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "b8858dddbf7b7f1ee3033acfab3d6f54a0ed3114",
+        "rev": "b7782daacebf8842bece6e41a20ee9a4859721e6",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1711352745,
-        "narHash": "sha256-luvqik+i3HTvCbXQZgB6uggvEcxI9uae0nmrgtXJ17U=",
+        "lastModified": 1716173274,
+        "narHash": "sha256-FC21Bn4m6ctajMjiUof30awPBH/7WjD0M5yqrWepZbY=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "9a763a7acc4cfbb8603bb0231fec3eda864f81c0",
+        "rev": "d9e0b26202fd500cf3e79f73653cce7f7d541191",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "lastModified": 1716137900,
+        "narHash": "sha256-sowPU+tLQv8GlqtVtsXioTKeaQvlMz/pefcdwg8MvfM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "6c0b7a92c30122196a761b440ac0d46d3d9954f1",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1711914285,
-        "narHash": "sha256-n7Bm62/s+t/S3xiZz33gp4HWgKfSOgYG5JzmT0gJoQ8=",
+        "lastModified": 1716256639,
+        "narHash": "sha256-y3ltagFY05wN4WCvIlthBlmVhEk5Z6sG9tdc6Q2fT9Q=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "327169ed2b4766f8112d4fb144bc8f8a7cebf8bd",
+        "rev": "6e96a6552babd35cd0bdcc180c6e5e82c8844990",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1711842437,
-        "narHash": "sha256-jttg9UokZ9c1tLTj22e8BN620q4/qJHnGR32xHsb9+k=",
+        "lastModified": 1716253768,
+        "narHash": "sha256-QRYKjRIzN50DRK3eyEulA915WUuJpHx9dy/VxbToxZ4=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "0cf7de598b2cbeba8fbe955baa0557de9d9df121",
+        "rev": "db37bead643ae3c0b7b6dd3942f3eb6e80b8f4d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/36524adc31566655f2f4d55ad6b875fb5c1a4083' (2024-03-30)
  → 'github:lnl7/nix-darwin/8bf083c992e2bc0a8c07f5860d3866739b698883' (2024-05-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/820be197ccf3adaad9a8856ef255c13b6cc561a6' (2024-03-31)
  → 'github:nix-community/home-manager/e3ad5108f54177e6520535768ddbf1e6af54b59d' (2024-05-17)
• Updated input 'neovim-flake':
    'github:neovim/neovim/b8858dddbf7b7f1ee3033acfab3d6f54a0ed3114?dir=contrib' (2024-04-01)
  → 'github:neovim/neovim/b7782daacebf8842bece6e41a20ee9a4859721e6?dir=contrib' (2024-05-20)
• Updated input 'neovim-flake/flake-utils':
    'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725' (2023-12-04)
  → 'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/9a763a7acc4cfbb8603bb0231fec3eda864f81c0' (2024-03-25)
  → 'github:nixos/nixos-hardware/d9e0b26202fd500cf3e79f73653cce7f7d541191' (2024-05-20)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d8fe5e6c92d0d190646fb9f1056741a229980089' (2024-03-29)
  → 'github:nixos/nixpkgs/6c0b7a92c30122196a761b440ac0d46d3d9954f1' (2024-05-19)
• Updated input 'nur':
    'github:nix-community/nur/327169ed2b4766f8112d4fb144bc8f8a7cebf8bd' (2024-03-31)
  → 'github:nix-community/nur/6e96a6552babd35cd0bdcc180c6e5e82c8844990' (2024-05-21)
• Updated input 'nushell-src':
    'github:nushell/nushell/0cf7de598b2cbeba8fbe955baa0557de9d9df121' (2024-03-30)
  → 'github:nushell/nushell/db37bead643ae3c0b7b6dd3942f3eb6e80b8f4d2' (2024-05-21)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`327169ed` ➡️ `6e96a655`](https://github.com/nix-community/nur/compare/327169ed2b4766f8112d4fb144bc8f8a7cebf8bd...6e96a6552babd35cd0bdcc180c6e5e82c8844990) <sub>(2024-03-31 to 2024-05-21)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`36524adc` ➡️ `8bf083c9`](https://github.com/lnl7/nix-darwin/compare/36524adc31566655f2f4d55ad6b875fb5c1a4083...8bf083c992e2bc0a8c07f5860d3866739b698883) <sub>(2024-03-30 to 2024-05-20)</sub>
 - Updated input [`neovim-flake/flake-utils`](https://github.com/numtide/flake-utils): [`4022d587` ➡️ `b1d9ab70`](https://github.com/numtide/flake-utils/compare/4022d587cbbfd70fe950c1e2083a02621806a725...b1d9ab70662946ef0850d488da1c9019f3a9752a) <sub>(2023-12-04 to 2024-03-11)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`d8fe5e6c` ➡️ `6c0b7a92`](https://github.com/nixos/nixpkgs/compare/d8fe5e6c92d0d190646fb9f1056741a229980089...6c0b7a92c30122196a761b440ac0d46d3d9954f1) <sub>(2024-03-29 to 2024-05-19)</sub>
 - Updated input [`neovim-flake`](https://github.com/neovim/neovim): [`b8858ddd` ➡️ `b7782daa`](https://github.com/neovim/neovim/compare/b8858dddbf7b7f1ee3033acfab3d6f54a0ed3114...b7782daacebf8842bece6e41a20ee9a4859721e6) <sub>(2024-04-01 to 2024-05-20)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`820be197` ➡️ `e3ad5108`](https://github.com/nix-community/home-manager/compare/820be197ccf3adaad9a8856ef255c13b6cc561a6...e3ad5108f54177e6520535768ddbf1e6af54b59d) <sub>(2024-03-31 to 2024-05-17)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`0cf7de59` ➡️ `db37bead`](https://github.com/nushell/nushell/compare/0cf7de598b2cbeba8fbe955baa0557de9d9df121...db37bead643ae3c0b7b6dd3942f3eb6e80b8f4d2) <sub>(2024-03-30 to 2024-05-21)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`9a763a7a` ➡️ `d9e0b262`](https://github.com/nixos/nixos-hardware/compare/9a763a7acc4cfbb8603bb0231fec3eda864f81c0...d9e0b26202fd500cf3e79f73653cce7f7d541191) <sub>(2024-03-25 to 2024-05-20)</sub>