### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716240091,
-        "narHash": "sha256-++gJuNv0X8naF1VkaO2sAiM3T4wLx1NtdfubEsRzX7U=",
+        "lastModified": 1720845312,
+        "narHash": "sha256-yPhAsJTpyoIPQZJGC8Fw8W2lAXyhLoTn+HP20bmfkfk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8bf083c992e2bc0a8c07f5860d3866739b698883",
+        "rev": "5ce8503cf402cf76b203eba4b7e402bea8e44abc",
         "type": "github"
       },
       "original": {
@@ -37,22 +37,78 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
+    "flake-compat_2": {
+      "flake": false,
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "edolstra",
+        "repo": "flake-compat",
         "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "neovim-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "neovim-flake",
+          "hercules-ci-effects",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
       }
     },
     "ghostty-module": {
@@ -70,6 +126,77 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "neovim-flake",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "neovim-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1720524665,
+        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "neovim-flake",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "neovim-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719226092,
+        "narHash": "sha256-YNkUMcCUCpnULp40g+svYsaH1RbSEj6s4WdZY/SHe38=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "11e4b8dc112e2f485d7c97e1cee77f9958f498f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -77,11 +204,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715930644,
-        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "lastModified": 1720734513,
+        "narHash": "sha256-neWQ8eNtLTd+YMesb7WjKl1SVCbDyCm46LUgP/g/hdo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "rev": "90ae324e2c56af10f20549ab72014804a3064c7f",
         "type": "github"
       },
       "original": {
@@ -92,22 +219,40 @@
     },
     "neovim-flake": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
+        "hercules-ci-effects": "hercules-ci-effects",
+        "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "dir": "contrib",
-        "lastModified": 1716248759,
-        "narHash": "sha256-9B1kGawSyC5LUiY+6aMwoeAprrVT2UXLQ6KeU/Is4aQ=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "b7782daacebf8842bece6e41a20ee9a4859721e6",
+        "lastModified": 1720861673,
+        "narHash": "sha256-gh34LtCLvXCd/Xyk33mgQU3QqNyJ7ZwJj59c4Qdad78=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "34b8101a10dfb4cb38832a17ef33281d59e2b2b3",
         "type": "github"
       },
       "original": {
-        "dir": "contrib",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "neovim-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1720816717,
+        "narHash": "sha256-C8bdG2wrI29afHI1705W37M7CPudz5117YafiBlW0Y4=",
+        "owner": "neovim",
+        "repo": "neovim",
+        "rev": "10256bb760fcab0dc25f7eb5b0b45966cb771939",
+        "type": "github"
+      },
+      "original": {
         "owner": "neovim",
         "repo": "neovim",
         "type": "github"
@@ -115,11 +260,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1716173274,
-        "narHash": "sha256-FC21Bn4m6ctajMjiUof30awPBH/7WjD0M5yqrWepZbY=",
+        "lastModified": 1720737798,
+        "narHash": "sha256-G/OtEAts7ZUvW5lrGMXSb8HqRp2Jr9I7reBuvCOL54w=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "d9e0b26202fd500cf3e79f73653cce7f7d541191",
+        "rev": "c5013aa7ce2c7ec90acee5d965d950c8348db751",
         "type": "github"
       },
       "original": {
@@ -130,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716137900,
-        "narHash": "sha256-sowPU+tLQv8GlqtVtsXioTKeaQvlMz/pefcdwg8MvfM=",
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c0b7a92c30122196a761b440ac0d46d3d9954f1",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
         "type": "github"
       },
       "original": {
@@ -146,11 +291,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716256639,
-        "narHash": "sha256-y3ltagFY05wN4WCvIlthBlmVhEk5Z6sG9tdc6Q2fT9Q=",
+        "lastModified": 1721039767,
+        "narHash": "sha256-0yQGyfxQ3J7ORsWeF1hnDU+bilrJZYWzhAtsqNfTSzM=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "6e96a6552babd35cd0bdcc180c6e5e82c8844990",
+        "rev": "f20826f2af46da77eaa3aacedb303ccdd09b9321",
         "type": "github"
       },
       "original": {
@@ -162,11 +307,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1716253768,
-        "narHash": "sha256-QRYKjRIzN50DRK3eyEulA915WUuJpHx9dy/VxbToxZ4=",
+        "lastModified": 1720946277,
+        "narHash": "sha256-kCixeas8pQN8V4fQ//BdQZwoQaKeHVsQJGAI32A8g1w=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "db37bead643ae3c0b7b6dd3942f3eb6e80b8f4d2",
+        "rev": "3d1145e75983de00354edda0ea8dfd2629bba06f",
         "type": "github"
       },
       "original": {
@@ -186,21 +331,6 @@
         "nixpkgs": "nixpkgs",
         "nur": "nur",
         "nushell-src": "nushell-src"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
     flake-compat.url = "github:edolstra/flake-compat";
     flake-compat.flake = false;
 
-    neovim-flake.url = "github:neovim/neovim?dir=contrib";
+    neovim-flake.url = "github:nix-community/neovim-nightly-overlay";
     neovim-flake.inputs.nixpkgs.follows = "nixpkgs";
 
     nushell-src.url = "github:nushell/nushell";


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/8bf083c992e2bc0a8c07f5860d3866739b698883' (2024-05-20)
  → 'github:lnl7/nix-darwin/5ce8503cf402cf76b203eba4b7e402bea8e44abc' (2024-07-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e3ad5108f54177e6520535768ddbf1e6af54b59d' (2024-05-17)
  → 'github:nix-community/home-manager/90ae324e2c56af10f20549ab72014804a3064c7f' (2024-07-11)
• Updated input 'neovim-flake':
    'github:neovim/neovim/b7782daacebf8842bece6e41a20ee9a4859721e6?dir=contrib' (2024-05-20)
  → 'github:nix-community/neovim-nightly-overlay/34b8101a10dfb4cb38832a17ef33281d59e2b2b3' (2024-07-13)
• Added input 'neovim-flake/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Added input 'neovim-flake/flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
• Added input 'neovim-flake/flake-parts/nixpkgs-lib':
    follows 'neovim-flake/nixpkgs'
• Removed input 'neovim-flake/flake-utils'
• Removed input 'neovim-flake/flake-utils/systems'
• Added input 'neovim-flake/git-hooks':
    'github:cachix/git-hooks.nix/8d6a17d0cdf411c55f12602624df6368ad86fac1' (2024-07-09)
• Added input 'neovim-flake/git-hooks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Added input 'neovim-flake/git-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Added input 'neovim-flake/git-hooks/gitignore/nixpkgs':
    follows 'neovim-flake/git-hooks/nixpkgs'
• Added input 'neovim-flake/git-hooks/nixpkgs':
    follows 'neovim-flake/nixpkgs'
• Added input 'neovim-flake/git-hooks/nixpkgs-stable':
    follows 'neovim-flake/nixpkgs'
• Added input 'neovim-flake/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/11e4b8dc112e2f485d7c97e1cee77f9958f498f5' (2024-06-24)
• Added input 'neovim-flake/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
• Added input 'neovim-flake/hercules-ci-effects/flake-parts/nixpkgs-lib':
    follows 'neovim-flake/hercules-ci-effects/nixpkgs'
• Added input 'neovim-flake/hercules-ci-effects/nixpkgs':
    follows 'neovim-flake/nixpkgs'
• Added input 'neovim-flake/neovim-src':
    'github:neovim/neovim/10256bb760fcab0dc25f7eb5b0b45966cb771939' (2024-07-12)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/d9e0b26202fd500cf3e79f73653cce7f7d541191' (2024-05-20)
  → 'github:nixos/nixos-hardware/c5013aa7ce2c7ec90acee5d965d950c8348db751' (2024-07-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6c0b7a92c30122196a761b440ac0d46d3d9954f1' (2024-05-19)
  → 'github:nixos/nixpkgs/693bc46d169f5af9c992095736e82c3488bf7dbb' (2024-07-14)
• Updated input 'nur':
    'github:nix-community/nur/6e96a6552babd35cd0bdcc180c6e5e82c8844990' (2024-05-21)
  → 'github:nix-community/nur/f20826f2af46da77eaa3aacedb303ccdd09b9321' (2024-07-15)
• Updated input 'nushell-src':
    'github:nushell/nushell/db37bead643ae3c0b7b6dd3942f3eb6e80b8f4d2' (2024-05-21)
  → 'github:nushell/nushell/3d1145e75983de00354edda0ea8dfd2629bba06f' (2024-07-14)

```

</p></details>

 - Added input [`neovim-flake/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/0f9255e01c2351cc7d116c072cb317785dd33b33/)
 - Updated input [`nur`](https://github.com/nix-community/nur): [`6e96a655` ➡️ `f20826f2`](https://github.com/nix-community/nur/compare/6e96a6552babd35cd0bdcc180c6e5e82c8844990...f20826f2af46da77eaa3aacedb303ccdd09b9321) <sub>(2024-05-21 to 2024-07-15)</sub>
 - Added input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [github.com/neovim/neovim](https://github.com/neovim/neovim/tree/10256bb760fcab0dc25f7eb5b0b45966cb771939/)
 - Added input `neovim-flake/git-hooks/nixpkgs`: ``
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`8bf083c9` ➡️ `5ce8503c`](https://github.com/lnl7/nix-darwin/compare/8bf083c992e2bc0a8c07f5860d3866739b698883...5ce8503cf402cf76b203eba4b7e402bea8e44abc) <sub>(2024-05-20 to 2024-07-13)</sub>
 - Removed input `neovim-flake/flake-utils`.
 - Added input [`neovim-flake/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/0f9255e01c2351cc7d116c072cb317785dd33b33/)
 - Added input [`neovim-flake/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [github.com/hercules-ci/hercules-ci-effects](https://github.com/hercules-ci/hercules-ci-effects/tree/11e4b8dc112e2f485d7c97e1cee77f9958f498f5/)
 - Removed input `neovim-flake/flake-utils/systems`.
 - Added input [`neovim-flake/git-hooks`](https://github.com/cachix/git-hooks.nix): [github.com/cachix/git-hooks.nix](https://github.com/cachix/git-hooks.nix/tree/8d6a17d0cdf411c55f12602624df6368ad86fac1/)
 - Added input [`neovim-flake/git-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`6c0b7a92` ➡️ `693bc46d`](https://github.com/nixos/nixpkgs/compare/6c0b7a92c30122196a761b440ac0d46d3d9954f1...693bc46d169f5af9c992095736e82c3488bf7dbb) <sub>(2024-05-19 to 2024-07-14)</sub>
 - Added input [`neovim-flake/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/9227223f6d922fee3c7b190b2cc238a99527bbb7/)
 - Added input `neovim-flake/hercules-ci-effects/nixpkgs`: ``
 - Added input `neovim-flake/hercules-ci-effects/flake-parts/nixpkgs-lib`: ``
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`b7782daa` ➡️ `34b8101a`](https://github.com/nix-community/neovim-nightly-overlay/compare/b7782daacebf8842bece6e41a20ee9a4859721e6...34b8101a10dfb4cb38832a17ef33281d59e2b2b3) <sub>(2024-05-20 to 2024-07-13)</sub>
 - Added input `neovim-flake/git-hooks/nixpkgs-stable`: ``
 - Added input `neovim-flake/git-hooks/gitignore/nixpkgs`: ``
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`e3ad5108` ➡️ `90ae324e`](https://github.com/nix-community/home-manager/compare/e3ad5108f54177e6520535768ddbf1e6af54b59d...90ae324e2c56af10f20549ab72014804a3064c7f) <sub>(2024-05-17 to 2024-07-11)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`db37bead` ➡️ `3d1145e7`](https://github.com/nushell/nushell/compare/db37bead643ae3c0b7b6dd3942f3eb6e80b8f4d2...3d1145e75983de00354edda0ea8dfd2629bba06f) <sub>(2024-05-21 to 2024-07-14)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`d9e0b262` ➡️ `c5013aa7`](https://github.com/nixos/nixos-hardware/compare/d9e0b26202fd500cf3e79f73653cce7f7d541191...c5013aa7ce2c7ec90acee5d965d950c8348db751) <sub>(2024-05-20 to 2024-07-11)</sub>
 - Added input [`neovim-flake/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/9126214d0a59633752a136528f5f3b9aa8565b7d/)
 - Added input `neovim-flake/flake-parts/nixpkgs-lib`: ``