### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716240091,
-        "narHash": "sha256-++gJuNv0X8naF1VkaO2sAiM3T4wLx1NtdfubEsRzX7U=",
+        "lastModified": 1720845312,
+        "narHash": "sha256-yPhAsJTpyoIPQZJGC8Fw8W2lAXyhLoTn+HP20bmfkfk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8bf083c992e2bc0a8c07f5860d3866739b698883",
+        "rev": "5ce8503cf402cf76b203eba4b7e402bea8e44abc",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1720524665,
+        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715930644,
-        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "lastModified": 1720734513,
+        "narHash": "sha256-neWQ8eNtLTd+YMesb7WjKl1SVCbDyCm46LUgP/g/hdo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "rev": "90ae324e2c56af10f20549ab72014804a3064c7f",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1721041329,
-        "narHash": "sha256-3g1alOd5QFCAHseCmScXVOWPc/FHaNkuEBUbprd2Oss=",
+        "lastModified": 1720816717,
+        "narHash": "sha256-C8bdG2wrI29afHI1705W37M7CPudz5117YafiBlW0Y4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "3c803483ac0db09fe4fd9dc81f618e7a247714cc",
+        "rev": "10256bb760fcab0dc25f7eb5b0b45966cb771939",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1716173274,
-        "narHash": "sha256-FC21Bn4m6ctajMjiUof30awPBH/7WjD0M5yqrWepZbY=",
+        "lastModified": 1720737798,
+        "narHash": "sha256-G/OtEAts7ZUvW5lrGMXSb8HqRp2Jr9I7reBuvCOL54w=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "d9e0b26202fd500cf3e79f73653cce7f7d541191",
+        "rev": "c5013aa7ce2c7ec90acee5d965d950c8348db751",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716137900,
-        "narHash": "sha256-sowPU+tLQv8GlqtVtsXioTKeaQvlMz/pefcdwg8MvfM=",
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c0b7a92c30122196a761b440ac0d46d3d9954f1",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1716256639,
-        "narHash": "sha256-y3ltagFY05wN4WCvIlthBlmVhEk5Z6sG9tdc6Q2fT9Q=",
+        "lastModified": 1721039767,
+        "narHash": "sha256-0yQGyfxQ3J7ORsWeF1hnDU+bilrJZYWzhAtsqNfTSzM=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "6e96a6552babd35cd0bdcc180c6e5e82c8844990",
+        "rev": "f20826f2af46da77eaa3aacedb303ccdd09b9321",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1716253768,
-        "narHash": "sha256-QRYKjRIzN50DRK3eyEulA915WUuJpHx9dy/VxbToxZ4=",
+        "lastModified": 1720946277,
+        "narHash": "sha256-kCixeas8pQN8V4fQ//BdQZwoQaKeHVsQJGAI32A8g1w=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "db37bead643ae3c0b7b6dd3942f3eb6e80b8f4d2",
+        "rev": "3d1145e75983de00354edda0ea8dfd2629bba06f",
         "type": "github"
       },
       "original": {

--- a/home/modules/shell/neovim.nix
+++ b/home/modules/shell/neovim.nix
@@ -31,10 +31,10 @@ in
         marksman
         nixd
         nodePackages.bash-language-server
-        nodePackages.pyright
         nodePackages.typescript-language-server
         nodePackages.vim-language-server
         nodePackages.write-good
+        pyright
       ] ++ optionals pkgs.stdenv.isLinux [
         omnisharp-roslyn
         lua-language-server

--- a/system/nixos/profiles/desktop/default.nix
+++ b/system/nixos/profiles/desktop/default.nix
@@ -33,7 +33,6 @@ in
     ];
 
     # Enable sound with pipewire.
-    sound.enable = true;
     hardware = {
       pulseaudio = {
         enable = false;


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/8bf083c992e2bc0a8c07f5860d3866739b698883' (2024-05-20)
  → 'github:lnl7/nix-darwin/5ce8503cf402cf76b203eba4b7e402bea8e44abc' (2024-07-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e3ad5108f54177e6520535768ddbf1e6af54b59d' (2024-05-17)
  → 'github:nix-community/home-manager/90ae324e2c56af10f20549ab72014804a3064c7f' (2024-07-11)
• Updated input 'neovim-flake/git-hooks':
    'github:cachix/git-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
  → 'github:cachix/git-hooks.nix/8d6a17d0cdf411c55f12602624df6368ad86fac1' (2024-07-09)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/3c803483ac0db09fe4fd9dc81f618e7a247714cc' (2024-07-15)
  → 'github:neovim/neovim/10256bb760fcab0dc25f7eb5b0b45966cb771939' (2024-07-12)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/d9e0b26202fd500cf3e79f73653cce7f7d541191' (2024-05-20)
  → 'github:nixos/nixos-hardware/c5013aa7ce2c7ec90acee5d965d950c8348db751' (2024-07-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6c0b7a92c30122196a761b440ac0d46d3d9954f1' (2024-05-19)
  → 'github:nixos/nixpkgs/693bc46d169f5af9c992095736e82c3488bf7dbb' (2024-07-14)
• Updated input 'nur':
    'github:nix-community/nur/6e96a6552babd35cd0bdcc180c6e5e82c8844990' (2024-05-21)
  → 'github:nix-community/nur/f20826f2af46da77eaa3aacedb303ccdd09b9321' (2024-07-15)
• Updated input 'nushell-src':
    'github:nushell/nushell/db37bead643ae3c0b7b6dd3942f3eb6e80b8f4d2' (2024-05-21)
  → 'github:nushell/nushell/3d1145e75983de00354edda0ea8dfd2629bba06f' (2024-07-14)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`6e96a655` ➡️ `f20826f2`](https://github.com/nix-community/nur/compare/6e96a6552babd35cd0bdcc180c6e5e82c8844990...f20826f2af46da77eaa3aacedb303ccdd09b9321) <sub>(2024-05-21 to 2024-07-15)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`3c803483` ➡️ `10256bb7`](https://github.com/neovim/neovim/compare/3c803483ac0db09fe4fd9dc81f618e7a247714cc...10256bb760fcab0dc25f7eb5b0b45966cb771939) <sub>(2024-07-15 to 2024-07-12)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`8bf083c9` ➡️ `5ce8503c`](https://github.com/lnl7/nix-darwin/compare/8bf083c992e2bc0a8c07f5860d3866739b698883...5ce8503cf402cf76b203eba4b7e402bea8e44abc) <sub>(2024-05-20 to 2024-07-13)</sub>
 - Updated input [`neovim-flake/git-hooks`](https://github.com/cachix/git-hooks.nix): [`f451c193` ➡️ `8d6a17d0`](https://github.com/cachix/git-hooks.nix/compare/f451c19376071a90d8c58ab1a953c6e9840527fd...8d6a17d0cdf411c55f12602624df6368ad86fac1) <sub>(2024-07-15 to 2024-07-09)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`6c0b7a92` ➡️ `693bc46d`](https://github.com/nixos/nixpkgs/compare/6c0b7a92c30122196a761b440ac0d46d3d9954f1...693bc46d169f5af9c992095736e82c3488bf7dbb) <sub>(2024-05-19 to 2024-07-14)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`e3ad5108` ➡️ `90ae324e`](https://github.com/nix-community/home-manager/compare/e3ad5108f54177e6520535768ddbf1e6af54b59d...90ae324e2c56af10f20549ab72014804a3064c7f) <sub>(2024-05-17 to 2024-07-11)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`db37bead` ➡️ `3d1145e7`](https://github.com/nushell/nushell/compare/db37bead643ae3c0b7b6dd3942f3eb6e80b8f4d2...3d1145e75983de00354edda0ea8dfd2629bba06f) <sub>(2024-05-21 to 2024-07-14)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`d9e0b262` ➡️ `c5013aa7`](https://github.com/nixos/nixos-hardware/compare/d9e0b26202fd500cf3e79f73653cce7f7d541191...c5013aa7ce2c7ec90acee5d965d950c8348db751) <sub>(2024-05-20 to 2024-07-11)</sub>