### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720845312,
-        "narHash": "sha256-yPhAsJTpyoIPQZJGC8Fw8W2lAXyhLoTn+HP20bmfkfk=",
+        "lastModified": 1722445220,
+        "narHash": "sha256-PW5FRqLhqg0xGpPjY2Poa464tyBQiyKd0tQGZ0HnMiU=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "5ce8503cf402cf76b203eba4b7e402bea8e44abc",
+        "rev": "7e08a9dd34314fb8051c28b231a68726c54daa7b",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720524665,
-        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720734513,
-        "narHash": "sha256-neWQ8eNtLTd+YMesb7WjKl1SVCbDyCm46LUgP/g/hdo=",
+        "lastModified": 1722462338,
+        "narHash": "sha256-ss0G8t8RJVDewA3MyqgAlV951cWRK6EtVhVKEZ7J5LU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "90ae324e2c56af10f20549ab72014804a3064c7f",
+        "rev": "6e090576c4824b16e8759ebca3958c5b09659ee8",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720861673,
-        "narHash": "sha256-gh34LtCLvXCd/Xyk33mgQU3QqNyJ7ZwJj59c4Qdad78=",
+        "lastModified": 1722471252,
+        "narHash": "sha256-rgNPBiWN+y2jBiXIEgV/McBfkPeZax80eol0FBoupCk=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "34b8101a10dfb4cb38832a17ef33281d59e2b2b3",
+        "rev": "fe7178b41d84add25c63a695620629050fb35bbd",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1720816717,
-        "narHash": "sha256-C8bdG2wrI29afHI1705W37M7CPudz5117YafiBlW0Y4=",
+        "lastModified": 1722463651,
+        "narHash": "sha256-3YorBqxT1RpL3Z2rLDCJhG+1HnBsgjrW8AOlTkFWlbA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "10256bb760fcab0dc25f7eb5b0b45966cb771939",
+        "rev": "e820474cde09273608be5f57e1032aab21e3c97d",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1720737798,
-        "narHash": "sha256-G/OtEAts7ZUvW5lrGMXSb8HqRp2Jr9I7reBuvCOL54w=",
+        "lastModified": 1722332872,
+        "narHash": "sha256-2xLM4sc5QBfi0U/AANJAW21Bj4ZX479MHPMPkB+eKBU=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "c5013aa7ce2c7ec90acee5d965d950c8348db751",
+        "rev": "14c333162ba53c02853add87a0000cbd7aa230c2",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720957393,
-        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "lastModified": 1722185531,
+        "narHash": "sha256-veKR07psFoJjINLC8RK4DiLniGGMgF3QMlS4tb74S6k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1721039767,
-        "narHash": "sha256-0yQGyfxQ3J7ORsWeF1hnDU+bilrJZYWzhAtsqNfTSzM=",
+        "lastModified": 1722465185,
+        "narHash": "sha256-vNu8ztiqTTAvgqYBatM/AuFn9qpJXfNuqGFYA95oVWk=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "f20826f2af46da77eaa3aacedb303ccdd09b9321",
+        "rev": "9ba05057d90d2c8fda1f40685871c0d8dbf81402",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1720946277,
-        "narHash": "sha256-kCixeas8pQN8V4fQ//BdQZwoQaKeHVsQJGAI32A8g1w=",
+        "lastModified": 1722461741,
+        "narHash": "sha256-vypGG1xWc0aivE8FXhJfYWBVOK/p81Bwi1vjeItzj/I=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "3d1145e75983de00354edda0ea8dfd2629bba06f",
+        "rev": "f82c43f850e966d826facb74ca25210dd51292a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/5ce8503cf402cf76b203eba4b7e402bea8e44abc' (2024-07-13)
  → 'github:lnl7/nix-darwin/7e08a9dd34314fb8051c28b231a68726c54daa7b' (2024-07-31)
• Updated input 'home-manager':
    'github:nix-community/home-manager/90ae324e2c56af10f20549ab72014804a3064c7f' (2024-07-11)
  → 'github:nix-community/home-manager/6e090576c4824b16e8759ebca3958c5b09659ee8' (2024-07-31)
• Updated input 'neovim-flake':
    'github:nix-community/neovim-nightly-overlay/34b8101a10dfb4cb38832a17ef33281d59e2b2b3' (2024-07-13)
  → 'github:nix-community/neovim-nightly-overlay/fe7178b41d84add25c63a695620629050fb35bbd' (2024-08-01)
• Updated input 'neovim-flake/git-hooks':
    'github:cachix/git-hooks.nix/8d6a17d0cdf411c55f12602624df6368ad86fac1' (2024-07-09)
  → 'github:cachix/git-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/10256bb760fcab0dc25f7eb5b0b45966cb771939' (2024-07-12)
  → 'github:neovim/neovim/e820474cde09273608be5f57e1032aab21e3c97d' (2024-07-31)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/c5013aa7ce2c7ec90acee5d965d950c8348db751' (2024-07-11)
  → 'github:nixos/nixos-hardware/14c333162ba53c02853add87a0000cbd7aa230c2' (2024-07-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/693bc46d169f5af9c992095736e82c3488bf7dbb' (2024-07-14)
  → 'github:nixos/nixpkgs/52ec9ac3b12395ad677e8b62106f0b98c1f8569d' (2024-07-28)
• Updated input 'nur':
    'github:nix-community/nur/f20826f2af46da77eaa3aacedb303ccdd09b9321' (2024-07-15)
  → 'github:nix-community/nur/9ba05057d90d2c8fda1f40685871c0d8dbf81402' (2024-07-31)
• Updated input 'nushell-src':
    'github:nushell/nushell/3d1145e75983de00354edda0ea8dfd2629bba06f' (2024-07-14)
  → 'github:nushell/nushell/f82c43f850e966d826facb74ca25210dd51292a6' (2024-07-31)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`f20826f2` ➡️ `9ba05057`](https://github.com/nix-community/nur/compare/f20826f2af46da77eaa3aacedb303ccdd09b9321...9ba05057d90d2c8fda1f40685871c0d8dbf81402) <sub>(2024-07-15 to 2024-07-31)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`10256bb7` ➡️ `e820474c`](https://github.com/neovim/neovim/compare/10256bb760fcab0dc25f7eb5b0b45966cb771939...e820474cde09273608be5f57e1032aab21e3c97d) <sub>(2024-07-12 to 2024-07-31)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`5ce8503c` ➡️ `7e08a9dd`](https://github.com/lnl7/nix-darwin/compare/5ce8503cf402cf76b203eba4b7e402bea8e44abc...7e08a9dd34314fb8051c28b231a68726c54daa7b) <sub>(2024-07-13 to 2024-07-31)</sub>
 - Updated input [`neovim-flake/git-hooks`](https://github.com/cachix/git-hooks.nix): [`8d6a17d0` ➡️ `f451c193`](https://github.com/cachix/git-hooks.nix/compare/8d6a17d0cdf411c55f12602624df6368ad86fac1...f451c19376071a90d8c58ab1a953c6e9840527fd) <sub>(2024-07-09 to 2024-07-15)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`693bc46d` ➡️ `52ec9ac3`](https://github.com/nixos/nixpkgs/compare/693bc46d169f5af9c992095736e82c3488bf7dbb...52ec9ac3b12395ad677e8b62106f0b98c1f8569d) <sub>(2024-07-14 to 2024-07-28)</sub>
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`34b8101a` ➡️ `fe7178b4`](https://github.com/nix-community/neovim-nightly-overlay/compare/34b8101a10dfb4cb38832a17ef33281d59e2b2b3...fe7178b41d84add25c63a695620629050fb35bbd) <sub>(2024-07-13 to 2024-08-01)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`90ae324e` ➡️ `6e090576`](https://github.com/nix-community/home-manager/compare/90ae324e2c56af10f20549ab72014804a3064c7f...6e090576c4824b16e8759ebca3958c5b09659ee8) <sub>(2024-07-11 to 2024-07-31)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`3d1145e7` ➡️ `f82c43f8`](https://github.com/nushell/nushell/compare/3d1145e75983de00354edda0ea8dfd2629bba06f...f82c43f850e966d826facb74ca25210dd51292a6) <sub>(2024-07-14 to 2024-07-31)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`c5013aa7` ➡️ `14c33316`](https://github.com/nixos/nixos-hardware/compare/c5013aa7ce2c7ec90acee5d965d950c8348db751...14c333162ba53c02853add87a0000cbd7aa230c2) <sub>(2024-07-11 to 2024-07-30)</sub>