### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722924007,
-        "narHash": "sha256-+CQDamNwqO33REJLft8c26NbUi2Td083hq6SvAm2xkU=",
+        "lastModified": 1724994893,
+        "narHash": "sha256-yutISDGg6HUaZqCaa54EcsfTwew3vhNtt/FNXBBo44g=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "91010a5613ffd7ee23ee9263213157a1c422b705",
+        "rev": "c8d3157d1f768e382de5526bb38e74d2245cad04",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723202784,
-        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
+        "lastModified": 1724857454,
+        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
+        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719226092,
-        "narHash": "sha256-YNkUMcCUCpnULp40g+svYsaH1RbSEj6s4WdZY/SHe38=",
+        "lastModified": 1724947644,
+        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "11e4b8dc112e2f485d7c97e1cee77f9958f498f5",
+        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723399884,
-        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
+        "lastModified": 1724435763,
+        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
+        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723614748,
-        "narHash": "sha256-kNFdRdUvwTZOXt+mWCpb2Y99kqzAcBZqI/F/2fSjRJw=",
+        "lastModified": 1724996444,
+        "narHash": "sha256-bgDfNsVPleUyx6vNr5INJTLfkLycNmL3yvSBv1OguLs=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "4b239d8da3a4888b660653dabec18bcc7cf70f7a",
+        "rev": "d0f68c980e3a0a3a8e63ccca93a01f87fb77937e",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1723588927,
-        "narHash": "sha256-u4XYsa9td3shTsiDftC7B+HnPgHgY78NeJHxHNkXxFs=",
+        "lastModified": 1724970905,
+        "narHash": "sha256-6HqoxweeX3tQbchJpjUNiBKj/2P3oiQBR42B/QuB+a0=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "9d74dc3ac5a66d0fd34de125476a92ec0a77ca58",
+        "rev": "4353996d0fa8e5872a334d68196d8088391960cf",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1723310128,
-        "narHash": "sha256-IiH8jG6PpR4h9TxSGMYh+2/gQiJW9MwehFvheSb5rPc=",
+        "lastModified": 1724878143,
+        "narHash": "sha256-UjpKo92iZ25M05kgSOw/Ti6VZwpgdlOa73zHj8OcaDk=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf",
+        "rev": "95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723362943,
-        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1723664702,
-        "narHash": "sha256-ErRJ3oUHFOzUXoDAzws/h5u7c6dCExETjmm5uIFL/QY=",
+        "lastModified": 1725136319,
+        "narHash": "sha256-JWaKbrxiRNfcqUj8hJekDk9OseGQXf6iJKZ5c1nHbUg=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "7bcbb0362c92f230ba4a2c5ad227e04f84fc1ce0",
+        "rev": "b9574ca13d057528cd721d87d8158dd463a10fb9",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1723669860,
-        "narHash": "sha256-288MdSfxJItH4N/443r3+JjDLLCHnxWdzTYvlNr7qtA=",
+        "lastModified": 1725115515,
+        "narHash": "sha256-k9H1MPZXtu86E/zBgilZ0bN9RKXujm+jBYh4eAxrey0=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "31b3104af7144011ffd2bc5da4e1318c37b02420",
+        "rev": "3f31ca7b8eedff4a48f5213357d9c64a751408a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/91010a5613ffd7ee23ee9263213157a1c422b705' (2024-08-06)
  → 'github:lnl7/nix-darwin/c8d3157d1f768e382de5526bb38e74d2245cad04' (2024-08-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/086f619dd991a4d355c07837448244029fc2d9ab' (2024-08-11)
  → 'github:nix-community/home-manager/c2cd2a52e02f1dfa1c88f95abeb89298d46023be' (2024-08-23)
• Updated input 'neovim-flake':
    'github:nix-community/neovim-nightly-overlay/4b239d8da3a4888b660653dabec18bcc7cf70f7a' (2024-08-14)
  → 'github:nix-community/neovim-nightly-overlay/d0f68c980e3a0a3a8e63ccca93a01f87fb77937e' (2024-08-30)
• Updated input 'neovim-flake/git-hooks':
    'github:cachix/git-hooks.nix/c7012d0c18567c889b948781bc74a501e92275d1' (2024-08-09)
  → 'github:cachix/git-hooks.nix/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6' (2024-08-28)
• Updated input 'neovim-flake/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/11e4b8dc112e2f485d7c97e1cee77f9958f498f5' (2024-06-24)
  → 'github:hercules-ci/hercules-ci-effects/dba4367b9a9d9615456c430a6d6af716f6e84cef' (2024-08-29)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/9d74dc3ac5a66d0fd34de125476a92ec0a77ca58' (2024-08-13)
  → 'github:neovim/neovim/4353996d0fa8e5872a334d68196d8088391960cf' (2024-08-29)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf' (2024-08-10)
  → 'github:nixos/nixos-hardware/95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef' (2024-08-28)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a58bc8ad779655e790115244571758e8de055e3d' (2024-08-11)
  → 'github:nixos/nixpkgs/71e91c409d1e654808b2621f28a327acfdad8dc2' (2024-08-28)
• Updated input 'nur':
    'github:nix-community/nur/7bcbb0362c92f230ba4a2c5ad227e04f84fc1ce0' (2024-08-14)
  → 'github:nix-community/nur/b9574ca13d057528cd721d87d8158dd463a10fb9' (2024-08-31)
• Updated input 'nushell-src':
    'github:nushell/nushell/31b3104af7144011ffd2bc5da4e1318c37b02420' (2024-08-14)
  → 'github:nushell/nushell/3f31ca7b8eedff4a48f5213357d9c64a751408a9' (2024-08-31)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`7bcbb036` ➡️ `b9574ca1`](https://github.com/nix-community/nur/compare/7bcbb0362c92f230ba4a2c5ad227e04f84fc1ce0...b9574ca13d057528cd721d87d8158dd463a10fb9) <sub>(2024-08-14 to 2024-08-31)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`9d74dc3a` ➡️ `4353996d`](https://github.com/neovim/neovim/compare/9d74dc3ac5a66d0fd34de125476a92ec0a77ca58...4353996d0fa8e5872a334d68196d8088391960cf) <sub>(2024-08-13 to 2024-08-29)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`91010a56` ➡️ `c8d3157d`](https://github.com/lnl7/nix-darwin/compare/91010a5613ffd7ee23ee9263213157a1c422b705...c8d3157d1f768e382de5526bb38e74d2245cad04) <sub>(2024-08-06 to 2024-08-30)</sub>
 - Updated input [`neovim-flake/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`11e4b8dc` ➡️ `dba4367b`](https://github.com/hercules-ci/hercules-ci-effects/compare/11e4b8dc112e2f485d7c97e1cee77f9958f498f5...dba4367b9a9d9615456c430a6d6af716f6e84cef) <sub>(2024-06-24 to 2024-08-29)</sub>
 - Updated input [`neovim-flake/git-hooks`](https://github.com/cachix/git-hooks.nix): [`c7012d0c` ➡️ `4509ca64`](https://github.com/cachix/git-hooks.nix/compare/c7012d0c18567c889b948781bc74a501e92275d1...4509ca64f1084e73bc7a721b20c669a8d4c5ebe6) <sub>(2024-08-09 to 2024-08-28)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`a58bc8ad` ➡️ `71e91c40`](https://github.com/nixos/nixpkgs/compare/a58bc8ad779655e790115244571758e8de055e3d...71e91c409d1e654808b2621f28a327acfdad8dc2) <sub>(2024-08-11 to 2024-08-28)</sub>
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`4b239d8d` ➡️ `d0f68c98`](https://github.com/nix-community/neovim-nightly-overlay/compare/4b239d8da3a4888b660653dabec18bcc7cf70f7a...d0f68c980e3a0a3a8e63ccca93a01f87fb77937e) <sub>(2024-08-14 to 2024-08-30)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`086f619d` ➡️ `c2cd2a52`](https://github.com/nix-community/home-manager/compare/086f619dd991a4d355c07837448244029fc2d9ab...c2cd2a52e02f1dfa1c88f95abeb89298d46023be) <sub>(2024-08-11 to 2024-08-23)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`31b3104a` ➡️ `3f31ca7b`](https://github.com/nushell/nushell/compare/31b3104af7144011ffd2bc5da4e1318c37b02420...3f31ca7b8eedff4a48f5213357d9c64a751408a9) <sub>(2024-08-14 to 2024-08-31)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`c54cf53e` ➡️ `95c3dfe6`](https://github.com/nixos/nixos-hardware/compare/c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf...95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef) <sub>(2024-08-10 to 2024-08-28)</sub>