### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724994893,
-        "narHash": "sha256-yutISDGg6HUaZqCaa54EcsfTwew3vhNtt/FNXBBo44g=",
+        "lastModified": 1725189302,
+        "narHash": "sha256-IhXok/kwQqtusPsoguQLCHA+h6gKvgdCrkhIaN+kByA=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "c8d3157d1f768e382de5526bb38e74d2245cad04",
+        "rev": "7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724435763,
-        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
+        "lastModified": 1725180166,
+        "narHash": "sha256-fzssXuGR/mCeGbzM1ExaTqDz7QDGta3WA4jJsZyRruo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "rev": "471e3eb0a114265bcd62d11d58ba8d3421ee68eb",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724996444,
-        "narHash": "sha256-bgDfNsVPleUyx6vNr5INJTLfkLycNmL3yvSBv1OguLs=",
+        "lastModified": 1725346719,
+        "narHash": "sha256-+QUffIvhBPdJNPbTUPdheijA1eQeAHlgvJqZ0qMPL34=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "d0f68c980e3a0a3a8e63ccca93a01f87fb77937e",
+        "rev": "ce477ade892d794fd21725d0525bc45739fdf64e",
         "type": "github"
       },
       "original": {
@@ -245,11 +245,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1724970905,
-        "narHash": "sha256-6HqoxweeX3tQbchJpjUNiBKj/2P3oiQBR42B/QuB+a0=",
+        "lastModified": 1725317538,
+        "narHash": "sha256-tRRSljYBy1GxQGaCvSywtCSJ+OQa6clYilJLMxTe+nM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "4353996d0fa8e5872a334d68196d8088391960cf",
+        "rev": "ae9674704ac5586438f60c883e918d448ef0e237",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724819573,
-        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1725136319,
-        "narHash": "sha256-JWaKbrxiRNfcqUj8hJekDk9OseGQXf6iJKZ5c1nHbUg=",
+        "lastModified": 1725367994,
+        "narHash": "sha256-H0RJ9+pmXnUgdQzj4Hq45khxpkD8jKxgc3qMzxaTFqY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "b9574ca13d057528cd721d87d8158dd463a10fb9",
+        "rev": "8b7d030200a43ec6b2b794c94b6142709a231203",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725115515,
-        "narHash": "sha256-k9H1MPZXtu86E/zBgilZ0bN9RKXujm+jBYh4eAxrey0=",
+        "lastModified": 1725287393,
+        "narHash": "sha256-mRq/9h/ItB16oO4ShYjXJ1PAWu5HrvoGhfVjpxUFqS8=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "3f31ca7b8eedff4a48f5213357d9c64a751408a9",
+        "rev": "c150af42795d4078f0ea3b66eb1fe60d3373e510",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/c8d3157d1f768e382de5526bb38e74d2245cad04' (2024-08-30)
  → 'github:lnl7/nix-darwin/7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda' (2024-09-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c2cd2a52e02f1dfa1c88f95abeb89298d46023be' (2024-08-23)
  → 'github:nix-community/home-manager/471e3eb0a114265bcd62d11d58ba8d3421ee68eb' (2024-09-01)
• Updated input 'neovim-flake':
    'github:nix-community/neovim-nightly-overlay/d0f68c980e3a0a3a8e63ccca93a01f87fb77937e' (2024-08-30)
  → 'github:nix-community/neovim-nightly-overlay/ce477ade892d794fd21725d0525bc45739fdf64e' (2024-09-03)
• Updated input 'neovim-flake/flake-parts':
    'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
  → 'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/4353996d0fa8e5872a334d68196d8088391960cf' (2024-08-29)
  → 'github:neovim/neovim/ae9674704ac5586438f60c883e918d448ef0e237' (2024-09-02)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/71e91c409d1e654808b2621f28a327acfdad8dc2' (2024-08-28)
  → 'github:nixos/nixpkgs/12228ff1752d7b7624a54e9c1af4b222b3c1073b' (2024-08-31)
• Updated input 'nur':
    'github:nix-community/nur/b9574ca13d057528cd721d87d8158dd463a10fb9' (2024-08-31)
  → 'github:nix-community/nur/8b7d030200a43ec6b2b794c94b6142709a231203' (2024-09-03)
• Updated input 'nushell-src':
    'github:nushell/nushell/3f31ca7b8eedff4a48f5213357d9c64a751408a9' (2024-08-31)
  → 'github:nushell/nushell/c150af42795d4078f0ea3b66eb1fe60d3373e510' (2024-09-02)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`b9574ca1` ➡️ `8b7d0302`](https://github.com/nix-community/nur/compare/b9574ca13d057528cd721d87d8158dd463a10fb9...8b7d030200a43ec6b2b794c94b6142709a231203) <sub>(2024-08-31 to 2024-09-03)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`4353996d` ➡️ `ae967470`](https://github.com/neovim/neovim/compare/4353996d0fa8e5872a334d68196d8088391960cf...ae9674704ac5586438f60c883e918d448ef0e237) <sub>(2024-08-29 to 2024-09-02)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`c8d3157d` ➡️ `7c4b53a7`](https://github.com/lnl7/nix-darwin/compare/c8d3157d1f768e382de5526bb38e74d2245cad04...7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda) <sub>(2024-08-30 to 2024-09-01)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`71e91c40` ➡️ `12228ff1`](https://github.com/nixos/nixpkgs/compare/71e91c409d1e654808b2621f28a327acfdad8dc2...12228ff1752d7b7624a54e9c1af4b222b3c1073b) <sub>(2024-08-28 to 2024-08-31)</sub>
 - Updated input [`neovim-flake/flake-parts`](https://github.com/hercules-ci/flake-parts): [`8471fe90` ➡️ `567b938d`](https://github.com/hercules-ci/flake-parts/compare/8471fe90ad337a8074e957b69ca4d0089218391d...567b938d64d4b4112ee253b9274472dc3a346eb6) <sub>(2024-08-01 to 2024-09-01)</sub>
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`d0f68c98` ➡️ `ce477ade`](https://github.com/nix-community/neovim-nightly-overlay/compare/d0f68c980e3a0a3a8e63ccca93a01f87fb77937e...ce477ade892d794fd21725d0525bc45739fdf64e) <sub>(2024-08-30 to 2024-09-03)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c2cd2a52` ➡️ `471e3eb0`](https://github.com/nix-community/home-manager/compare/c2cd2a52e02f1dfa1c88f95abeb89298d46023be...471e3eb0a114265bcd62d11d58ba8d3421ee68eb) <sub>(2024-08-23 to 2024-09-01)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`3f31ca7b` ➡️ `c150af42`](https://github.com/nushell/nushell/compare/3f31ca7b8eedff4a48f5213357d9c64a751408a9...c150af42795d4078f0ea3b66eb1fe60d3373e510) <sub>(2024-08-31 to 2024-09-02)</sub>