### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725189302,
-        "narHash": "sha256-IhXok/kwQqtusPsoguQLCHA+h6gKvgdCrkhIaN+kByA=",
+        "lastModified": 1733570843,
+        "narHash": "sha256-sQJAxY1TYWD1UyibN/FnN97paTFuwBw3Vp3DNCyKsMk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda",
+        "rev": "a35b08d09efda83625bef267eb24347b446c80b8",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -99,16 +99,37 @@
         ]
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
         "id": "flake-parts",
         "type": "indirect"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
       }
     },
     "ghostty-module": {
@@ -140,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1733665616,
+        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
         "type": "github"
       },
       "original": {
@@ -184,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724947644,
-        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
+        "lastModified": 1733333617,
+        "narHash": "sha256-nMMQXREGvLOLvUa0ByhYFdaL0Jov0t1wzLbKjr05P2w=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
+        "rev": "56f8ea8d502c87cf62444bec4ee04512e8ea24ea",
         "type": "github"
       },
       "original": {
@@ -227,14 +248,15 @@
         "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1725346719,
-        "narHash": "sha256-+QUffIvhBPdJNPbTUPdheijA1eQeAHlgvJqZ0qMPL34=",
+        "lastModified": 1734048484,
+        "narHash": "sha256-EtSEYNx19xzuEBJsT7yXG+nVx11CM3rvrAQAXcvG/5Q=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "ce477ade892d794fd21725d0525bc45739fdf64e",
+        "rev": "044f9a36ad620a119ebe154c26ec571a09f75039",
         "type": "github"
       },
       "original": {
@@ -246,11 +268,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725317538,
-        "narHash": "sha256-tRRSljYBy1GxQGaCvSywtCSJ+OQa6clYilJLMxTe+nM=",
+        "lastModified": 1734000357,
+        "narHash": "sha256-8FO5Ca9bLEiD649b5gkQCdjpTmbPenJHpN0JBhtLpjE=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "ae9674704ac5586438f60c883e918d448ef0e237",
+        "rev": "17383870dd3b7f04eddd48ed929cc25c7e102277",
         "type": "github"
       },
       "original": {
@@ -261,11 +283,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1724878143,
-        "narHash": "sha256-UjpKo92iZ25M05kgSOw/Ti6VZwpgdlOa73zHj8OcaDk=",
+        "lastModified": 1733861262,
+        "narHash": "sha256-+jjPup/ByS0LEVIrBbt7FnGugJgLeG9oc+ivFASYn2U=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef",
+        "rev": "cf737e2eba82b603f54f71b10cb8fd09d22ce3f5",
         "type": "github"
       },
       "original": {
@@ -276,11 +298,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729691686,
-        "narHash": "sha256-BAuPWW+9fa1moZTU+jFh+1cUtmsuF8asgzFwejM4wac=",
+        "lastModified": 1734017764,
+        "narHash": "sha256-msOfmyJSjAHgIygI/JD0Ae3JsDv4rT54Nlfr5t6MQMQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32e940c7c420600ef0d1ef396dc63b04ee9cad37",
+        "rev": "64e9404f308e0f0a0d8cdd7c358f74e34802494b",
         "type": "github"
       },
       "original": {
@@ -290,13 +312,34 @@
         "type": "github"
       }
     },
-    "nur": {
+    "nixpkgs_2": {
       "locked": {
-        "lastModified": 1725367994,
-        "narHash": "sha256-H0RJ9+pmXnUgdQzj4Hq45khxpkD8jKxgc3qMzxaTFqY=",
+        "lastModified": 1733940404,
+        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nur": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": "nixpkgs_2",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1734221225,
+        "narHash": "sha256-PQtNGbg3B93+MINMe4/mwYWZkVDNzaf+O2Hw7xDznNk=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "8b7d030200a43ec6b2b794c94b6142709a231203",
+        "rev": "12bcdb7c86a2598761a7e2ada1b1e6cd7542197c",
         "type": "github"
       },
       "original": {
@@ -308,11 +351,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725287393,
-        "narHash": "sha256-mRq/9h/ItB16oO4ShYjXJ1PAWu5HrvoGhfVjpxUFqS8=",
+        "lastModified": 1734222961,
+        "narHash": "sha256-7MTQ1rAuH/GkbXRWWTTCWruxXsp8bW7CE4/tZKyP3AY=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "c150af42795d4078f0ea3b66eb1fe60d3373e510",
+        "rev": "219b44a04f0d22adfd0c733158a8228571723f5a",
         "type": "github"
       },
       "original": {
@@ -342,16 +385,58 @@
         ]
       },
       "locked": {
-        "lastModified": 1731464916,
-        "narHash": "sha256-WZ5rpjr/wCt7yBOUsvDE2i22hYz9g8W921jlwVktRQ4=",
+        "lastModified": 1734143514,
+        "narHash": "sha256-1+r8wYucn8kp9d/IBW1uYGs31QQmSZURElsiOTx65xM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2c19bad6e881b5a154cafb7f9106879b5b356d1f",
+        "rev": "81fe5c27cb281a9b796d7ad05ad9179e5bd0c78d",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "neovim-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733761991,
+        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733222881,
+        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda' (2024-09-01)
  → 'github:lnl7/nix-darwin/a35b08d09efda83625bef267eb24347b446c80b8' (2024-12-07)
• Updated input 'flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec' (2024-12-04)
• Updated input 'neovim-flake':
    'github:nix-community/neovim-nightly-overlay/ce477ade892d794fd21725d0525bc45739fdf64e' (2024-09-03)
  → 'github:nix-community/neovim-nightly-overlay/044f9a36ad620a119ebe154c26ec571a09f75039' (2024-12-13)
• Updated input 'neovim-flake/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec' (2024-12-04)
• Updated input 'neovim-flake/flake-parts':
    'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
  → 'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
• Updated input 'neovim-flake/git-hooks':
    'github:cachix/git-hooks.nix/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6' (2024-08-28)
  → 'github:cachix/git-hooks.nix/d8c02f0ffef0ef39f6063731fc539d8c71eb463a' (2024-12-08)
• Updated input 'neovim-flake/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/dba4367b9a9d9615456c430a6d6af716f6e84cef' (2024-08-29)
  → 'github:hercules-ci/hercules-ci-effects/56f8ea8d502c87cf62444bec4ee04512e8ea24ea' (2024-12-04)
• Updated input 'neovim-flake/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
  → 'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/ae9674704ac5586438f60c883e918d448ef0e237' (2024-09-02)
  → 'github:neovim/neovim/17383870dd3b7f04eddd48ed929cc25c7e102277' (2024-12-12)
• Added input 'neovim-flake/treefmt-nix':
    'github:numtide/treefmt-nix/0ce9d149d99bc383d1f2d85f31f6ebd146e46085' (2024-12-09)
• Added input 'neovim-flake/treefmt-nix/nixpkgs':
    follows 'neovim-flake/nixpkgs'
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef' (2024-08-28)
  → 'github:nixos/nixos-hardware/cf737e2eba82b603f54f71b10cb8fd09d22ce3f5' (2024-12-10)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/32e940c7c420600ef0d1ef396dc63b04ee9cad37' (2024-10-23)
  → 'github:nixos/nixpkgs/64e9404f308e0f0a0d8cdd7c358f74e34802494b' (2024-12-12)
• Updated input 'nur':
    'github:nix-community/nur/8b7d030200a43ec6b2b794c94b6142709a231203' (2024-09-03)
  → 'github:nix-community/nur/12bcdb7c86a2598761a7e2ada1b1e6cd7542197c' (2024-12-15)
• Added input 'nur/flake-parts':
    'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
• Added input 'nur/flake-parts/nixpkgs-lib':
    follows 'nur/nixpkgs'
• Added input 'nur/nixpkgs':
    'github:nixos/nixpkgs/5d67ea6b4b63378b9c13be21e2ec9d1afc921713' (2024-12-11)
• Added input 'nur/treefmt-nix':
    'github:numtide/treefmt-nix/49717b5af6f80172275d47a418c9719a31a78b53' (2024-12-03)
• Added input 'nur/treefmt-nix/nixpkgs':
    follows 'nur/nixpkgs'
• Updated input 'nushell-src':
    'github:nushell/nushell/c150af42795d4078f0ea3b66eb1fe60d3373e510' (2024-09-02)
  → 'github:nushell/nushell/219b44a04f0d22adfd0c733158a8228571723f5a' (2024-12-15)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/2c19bad6e881b5a154cafb7f9106879b5b356d1f' (2024-11-13)
  → 'github:oxalica/rust-overlay/81fe5c27cb281a9b796d7ad05ad9179e5bd0c78d' (2024-12-14)

```

</p></details>

 - Added input `nur/treefmt-nix/nixpkgs`: ``
 - Updated input [`nur`](https://github.com/nix-community/nur): [`8b7d0302` ➡️ `12bcdb7c`](https://github.com/nix-community/nur/compare/8b7d030200a43ec6b2b794c94b6142709a231203...12bcdb7c86a2598761a7e2ada1b1e6cd7542197c) <sub>(2024-09-03 to 2024-12-15)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`ae967470` ➡️ `17383870`](https://github.com/neovim/neovim/compare/ae9674704ac5586438f60c883e918d448ef0e237...17383870dd3b7f04eddd48ed929cc25c7e102277) <sub>(2024-09-02 to 2024-12-12)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`7c4b53a7` ➡️ `a35b08d0`](https://github.com/lnl7/nix-darwin/compare/7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda...a35b08d09efda83625bef267eb24347b446c80b8) <sub>(2024-09-01 to 2024-12-07)</sub>
 - Updated input [`neovim-flake/flake-compat`](https://github.com/edolstra/flake-compat): [`0f9255e0` ➡️ `ff81ac96`](https://github.com/edolstra/flake-compat/compare/0f9255e01c2351cc7d116c072cb317785dd33b33...ff81ac966bb2cae68946d5ed5fc4994f96d0ffec) <sub>(2023-10-04 to 2024-12-04)</sub>
 - Added input `neovim-flake/treefmt-nix/nixpkgs`: ``
 - Added input [`neovim-flake/treefmt-nix`](https://github.com/numtide/treefmt-nix): [github.com/numtide/treefmt-nix](https://github.com/numtide/treefmt-nix/tree/0ce9d149d99bc383d1f2d85f31f6ebd146e46085/)
 - Updated input [`neovim-flake/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`dba4367b` ➡️ `56f8ea8d`](https://github.com/hercules-ci/hercules-ci-effects/compare/dba4367b9a9d9615456c430a6d6af716f6e84cef...56f8ea8d502c87cf62444bec4ee04512e8ea24ea) <sub>(2024-08-29 to 2024-12-04)</sub>
 - Updated input [`neovim-flake/git-hooks`](https://github.com/cachix/git-hooks.nix): [`4509ca64` ➡️ `d8c02f0f`](https://github.com/cachix/git-hooks.nix/compare/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6...d8c02f0ffef0ef39f6063731fc539d8c71eb463a) <sub>(2024-08-28 to 2024-12-08)</sub>
 - Added input [`nur/treefmt-nix`](https://github.com/numtide/treefmt-nix): [github.com/numtide/treefmt-nix](https://github.com/numtide/treefmt-nix/tree/49717b5af6f80172275d47a418c9719a31a78b53/)
 - Added input [`nur/nixpkgs`](https://github.com/nixos/nixpkgs): [github.com/nixos/nixpkgs](https://github.com/nixos/nixpkgs/tree/5d67ea6b4b63378b9c13be21e2ec9d1afc921713/)
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`32e940c7` ➡️ `64e9404f`](https://github.com/nixos/nixpkgs/compare/32e940c7c420600ef0d1ef396dc63b04ee9cad37...64e9404f308e0f0a0d8cdd7c358f74e34802494b) <sub>(2024-10-23 to 2024-12-12)</sub>
 - Updated input [`neovim-flake/flake-parts`](https://github.com/hercules-ci/flake-parts): [`567b938d` ➡️ `205b12d8`](https://github.com/hercules-ci/flake-parts/compare/567b938d64d4b4112ee253b9274472dc3a346eb6...205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9) <sub>(2024-09-01 to 2024-12-04)</sub>
 - Updated input [`flake-compat`](https://github.com/edolstra/flake-compat): [`0f9255e0` ➡️ `ff81ac96`](https://github.com/edolstra/flake-compat/compare/0f9255e01c2351cc7d116c072cb317785dd33b33...ff81ac966bb2cae68946d5ed5fc4994f96d0ffec) <sub>(2023-10-04 to 2024-12-04)</sub>
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`ce477ade` ➡️ `044f9a36`](https://github.com/nix-community/neovim-nightly-overlay/compare/ce477ade892d794fd21725d0525bc45739fdf64e...044f9a36ad620a119ebe154c26ec571a09f75039) <sub>(2024-09-03 to 2024-12-13)</sub>
 - Added input [`nur/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9/)
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`2c19bad6` ➡️ `81fe5c27`](https://github.com/oxalica/rust-overlay/compare/2c19bad6e881b5a154cafb7f9106879b5b356d1f...81fe5c27cb281a9b796d7ad05ad9179e5bd0c78d) <sub>(2024-11-13 to 2024-12-14)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`c150af42` ➡️ `219b44a0`](https://github.com/nushell/nushell/compare/c150af42795d4078f0ea3b66eb1fe60d3373e510...219b44a04f0d22adfd0c733158a8228571723f5a) <sub>(2024-09-02 to 2024-12-15)</sub>
 - Added input `nur/flake-parts/nixpkgs-lib`: ``
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`95c3dfe6` ➡️ `cf737e2e`](https://github.com/nixos/nixos-hardware/compare/95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef...cf737e2eba82b603f54f71b10cb8fd09d22ce3f5) <sub>(2024-08-28 to 2024-12-10)</sub>
 - Updated input [`neovim-flake/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9126214d` ➡️ `205b12d8`](https://github.com/hercules-ci/flake-parts/compare/9126214d0a59633752a136528f5f3b9aa8565b7d...205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9) <sub>(2024-04-01 to 2024-12-04)</sub>