### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725189302,
-        "narHash": "sha256-IhXok/kwQqtusPsoguQLCHA+h6gKvgdCrkhIaN+kByA=",
+        "lastModified": 1741229100,
+        "narHash": "sha256-0HwrTDXp9buEwal/1ymK9uQmzUD5ozIA7CJGqnT/gLs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda",
+        "rev": "adf5c88ba1fe21af5c083b4d655004431f20c5ab",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -127,16 +127,37 @@
         "type": "indirect"
       }
     },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -148,16 +169,18 @@
     "ghostty": {
       "inputs": {
         "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils",
         "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "zig": "zig"
+        "zig": "zig",
+        "zig2nix": "zig2nix"
       },
       "locked": {
-        "lastModified": 1735362327,
-        "narHash": "sha256-kD49xAUMCWU60IRKoJiyJTaEUum7rk45OYjZfwWr3Ck=",
+        "lastModified": 1741531864,
+        "narHash": "sha256-PXpsBVZ7plbjoJCUKCh6yBAS7c+OT7RZXjU3YsrypkI=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "6cbd69da7839260508466f9dfb2bc0c0fbb43991",
+        "rev": "843cc83f42a9677bb998b8b16a00aac68e6f53aa",
         "type": "github"
       },
       "original": {
@@ -173,18 +196,14 @@
         "nixpkgs": [
           "neovim-flake",
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "neovim-flake",
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1741379162,
+        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
         "type": "github"
       },
       "original": {
@@ -224,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724947644,
-        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
+        "lastModified": 1739595404,
+        "narHash": "sha256-0CjCfbq0yHWexOrpO06e2WU1r5JAqR6ffy1zgM3NksI=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
+        "rev": "06519cec8fb32d219006da6eacd255504a9996af",
         "type": "github"
       },
       "original": {
@@ -244,11 +263,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733050161,
-        "narHash": "sha256-lYnT+EYE47f5yY3KS/Kd4pJ6CO9fhCqumkYYkQ3TK20=",
+        "lastModified": 1739757849,
+        "narHash": "sha256-Gs076ot1YuAAsYVcyidLKUMIc4ooOaRGO0PqTY7sBzA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "62d536255879be574ebfe9b87c4ac194febf47c5",
+        "rev": "9d3d080aec2a35e05a15cedd281c2384767c2cfe",
         "type": "github"
       },
       "original": {
@@ -267,14 +286,15 @@
         "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1725346719,
-        "narHash": "sha256-+QUffIvhBPdJNPbTUPdheijA1eQeAHlgvJqZ0qMPL34=",
+        "lastModified": 1741531860,
+        "narHash": "sha256-DnUUKsVqyCfgdIEUQvOlL+D8zLqTCbFE5cA9mB/Yaj4=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "ce477ade892d794fd21725d0525bc45739fdf64e",
+        "rev": "370f8d7cd5610dfb6aa4c99aa1a34c9b17f7085a",
         "type": "github"
       },
       "original": {
@@ -286,11 +306,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725317538,
-        "narHash": "sha256-tRRSljYBy1GxQGaCvSywtCSJ+OQa6clYilJLMxTe+nM=",
+        "lastModified": 1741473351,
+        "narHash": "sha256-igPvhGYRyNGLQBlKCxDb4qGoznG8/E1mOVCG4aQyRQ4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "ae9674704ac5586438f60c883e918d448ef0e237",
+        "rev": "e02ee7410a6d04b32ec38af9f4ffdcf0798a0f0b",
         "type": "github"
       },
       "original": {
@@ -306,11 +326,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735443188,
-        "narHash": "sha256-AydPpRBh8+NOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8=",
+        "lastModified": 1741490098,
+        "narHash": "sha256-/tjVMbMzxJXrJaEk9N5esnbLebIZrkS1fbDJce/RiQg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "55ab1e1df5daf2476e6b826b69a82862dcbd7544",
+        "rev": "296a2c992a28b37427d062ade6e20d467e479e3f",
         "type": "github"
       },
       "original": {
@@ -321,11 +341,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1724878143,
-        "narHash": "sha256-UjpKo92iZ25M05kgSOw/Ti6VZwpgdlOa73zHj8OcaDk=",
+        "lastModified": 1741325094,
+        "narHash": "sha256-RUAdT8dZ6k/486vnu3tiNRrNW6+Q8uSD2Mq7gTX4jlo=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef",
+        "rev": "b48cc4dab0f9711af296fc367b6108cf7b8ccb16",
         "type": "github"
       },
       "original": {
@@ -336,11 +356,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733261153,
-        "narHash": "sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek=",
+        "lastModified": 1741445498,
+        "narHash": "sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b681065d0919f7eb5309a93cea2cfa84dec9aa88",
+        "rev": "52e3095f6d812b91b22fb7ad0bfc1ab416453634",
         "type": "github"
       },
       "original": {
@@ -352,11 +372,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1733423277,
-        "narHash": "sha256-TxabjxEgkNbCGFRHgM/b9yZWlBj60gUOUnRT/wbVQR8=",
+        "lastModified": 1738255539,
+        "narHash": "sha256-hP2eOqhIO/OILW+3moNWO4GtdJFYCqAe9yJZgvlCoDQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e36963a147267afc055f7cf65225958633e536bf",
+        "rev": "c3511a3b53b482aa7547c9d1626fd7310c1de1c5",
         "type": "github"
       },
       "original": {
@@ -368,11 +388,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1733229606,
-        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
+        "lastModified": 1738136902,
+        "narHash": "sha256-pUvLijVGARw4u793APze3j6mU1Zwdtz7hGkGGkD87qw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "rev": "9a5db3142ce450045840cc8d832b13b8a2018e0c",
         "type": "github"
       },
       "original": {
@@ -382,13 +402,34 @@
         "type": "github"
       }
     },
-    "nur": {
+    "nixpkgs_2": {
       "locked": {
-        "lastModified": 1725367994,
-        "narHash": "sha256-H0RJ9+pmXnUgdQzj4Hq45khxpkD8jKxgc3qMzxaTFqY=",
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nur": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": "nixpkgs_2",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1741556705,
+        "narHash": "sha256-fSrT9YPEIUe7YR2YgkyDT0rq1RxOIhwH8YtygSlBcM4=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "8b7d030200a43ec6b2b794c94b6142709a231203",
+        "rev": "38c5768166682ff0805919f88f51c6f3cda39286",
         "type": "github"
       },
       "original": {
@@ -400,11 +441,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725287393,
-        "narHash": "sha256-mRq/9h/ItB16oO4ShYjXJ1PAWu5HrvoGhfVjpxUFqS8=",
+        "lastModified": 1741552982,
+        "narHash": "sha256-NxR6YbPcfUcBd5K5G2PqM9iHwHjNK2drFxJZh58Ysms=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "c150af42795d4078f0ea3b66eb1fe60d3373e510",
+        "rev": "d97b2e3c60167688f159f460c728155580eb380d",
         "type": "github"
       },
       "original": {
@@ -435,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731464916,
-        "narHash": "sha256-WZ5rpjr/wCt7yBOUsvDE2i22hYz9g8W921jlwVktRQ4=",
+        "lastModified": 1741486734,
+        "narHash": "sha256-3hrpyTLNmnJpioVT1DDoVgsp7fWYkuS3JWCtfHsX1rk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2c19bad6e881b5a154cafb7f9106879b5b356d1f",
+        "rev": "d95582a900bd0e7e516ce3bed0503f742649fffb",
         "type": "github"
       },
       "original": {
@@ -463,28 +504,99 @@
         "type": "github"
       }
     },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "neovim-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739829690,
+        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733222881,
+        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
     "zig": {
       "inputs": {
         "flake-compat": [
           "ghostty"
         ],
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "ghostty",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "ghostty",
           "nixpkgs-stable"
         ]
       },
       "locked": {
-        "lastModified": 1717848532,
-        "narHash": "sha256-d+xIUvSTreHl8pAmU1fnmkfDTGQYCn2Rb/zOwByxS2M=",
+        "lastModified": 1738239110,
+        "narHash": "sha256-Y5i9mQ++dyIQr+zEPNy+KIbc5wjPmfllBrag3cHZgcE=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "02fc5cc555fc14fda40c42d7c3250efa43812b43",
+        "rev": "1a8fb6f3a04724519436355564b95fce5e272504",
         "type": "github"
       },
       "original": {
         "owner": "mitchellh",
         "repo": "zig-overlay",
+        "type": "github"
+      }
+    },
+    "zig2nix": {
+      "inputs": {
+        "flake-utils": [
+          "ghostty",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "ghostty",
+          "nixpkgs-stable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741368279,
+        "narHash": "sha256-WTaC8HmnIq6O71iK0g9as404BbmS+YyEP5qS85m2JBY=",
+        "owner": "jcollie",
+        "repo": "zig2nix",
+        "rev": "672971b5b6911de21446ad4fc76dee677922eda0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jcollie",
+        "ref": "672971b5b6911de21446ad4fc76dee677922eda0",
+        "repo": "zig2nix",
         "type": "github"
       }
     }


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda?narHash=sha256-IhXok/kwQqtusPsoguQLCHA%2Bh6gKvgdCrkhIaN%2BkByA%3D' (2024-09-01)
  → 'github:lnl7/nix-darwin/adf5c88ba1fe21af5c083b4d655004431f20c5ab?narHash=sha256-0HwrTDXp9buEwal/1ymK9uQmzUD5ozIA7CJGqnT/gLs%3D' (2025-03-06)
• Updated input 'flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33?narHash=sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U%3D' (2023-10-04)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
• Updated input 'ghostty':
    'github:ghostty-org/ghostty/6cbd69da7839260508466f9dfb2bc0c0fbb43991?narHash=sha256-kD49xAUMCWU60IRKoJiyJTaEUum7rk45OYjZfwWr3Ck%3D' (2024-12-28)
  → 'github:ghostty-org/ghostty/843cc83f42a9677bb998b8b16a00aac68e6f53aa?narHash=sha256-PXpsBVZ7plbjoJCUKCh6yBAS7c%2BOT7RZXjU3YsrypkI%3D' (2025-03-09)
• Updated input 'ghostty/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33?narHash=sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U%3D' (2023-10-04)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
• Added input 'ghostty/flake-utils':
    'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Added input 'ghostty/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
• Updated input 'ghostty/nixpkgs-stable':
    'github:nixos/nixpkgs/e36963a147267afc055f7cf65225958633e536bf?narHash=sha256-TxabjxEgkNbCGFRHgM/b9yZWlBj60gUOUnRT/wbVQR8%3D' (2024-12-05)
  → 'github:nixos/nixpkgs/c3511a3b53b482aa7547c9d1626fd7310c1de1c5?narHash=sha256-hP2eOqhIO/OILW%2B3moNWO4GtdJFYCqAe9yJZgvlCoDQ%3D' (2025-01-30)
• Updated input 'ghostty/nixpkgs-unstable':
    'github:nixos/nixpkgs/566e53c2ad750c84f6d31f9ccb9d00f823165550?narHash=sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE%3D' (2024-12-03)
  → 'github:nixos/nixpkgs/9a5db3142ce450045840cc8d832b13b8a2018e0c?narHash=sha256-pUvLijVGARw4u793APze3j6mU1Zwdtz7hGkGGkD87qw%3D' (2025-01-29)
• Updated input 'ghostty/zig':
    'github:mitchellh/zig-overlay/02fc5cc555fc14fda40c42d7c3250efa43812b43?narHash=sha256-d%2BxIUvSTreHl8pAmU1fnmkfDTGQYCn2Rb/zOwByxS2M%3D' (2024-06-08)
  → 'github:mitchellh/zig-overlay/1a8fb6f3a04724519436355564b95fce5e272504?narHash=sha256-Y5i9mQ%2B%2BdyIQr%2BzEPNy%2BKIbc5wjPmfllBrag3cHZgcE%3D' (2025-01-30)
• Updated input 'ghostty/zig/flake-utils':
    'github:numtide/flake-utils/1ef2e671c3b0c19053962c07dbda38332dcebf26?narHash=sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA%3D' (2024-01-15)
  → follows 'ghostty/flake-utils'
• Removed input 'ghostty/zig/flake-utils/systems'
• Added input 'ghostty/zig2nix':
    'github:jcollie/zig2nix/672971b5b6911de21446ad4fc76dee677922eda0?narHash=sha256-WTaC8HmnIq6O71iK0g9as404BbmS%2BYyEP5qS85m2JBY%3D' (2025-03-07)
• Added input 'ghostty/zig2nix/flake-utils':
    follows 'ghostty/flake-utils'
• Added input 'ghostty/zig2nix/nixpkgs':
    follows 'ghostty/nixpkgs-stable'
• Updated input 'home-manager':
    'github:nix-community/home-manager/62d536255879be574ebfe9b87c4ac194febf47c5?narHash=sha256-lYnT%2BEYE47f5yY3KS/Kd4pJ6CO9fhCqumkYYkQ3TK20%3D' (2024-12-01)
  → 'github:nix-community/home-manager/9d3d080aec2a35e05a15cedd281c2384767c2cfe?narHash=sha256-Gs076ot1YuAAsYVcyidLKUMIc4ooOaRGO0PqTY7sBzA%3D' (2025-02-17)
• Updated input 'neovim-flake':
    'github:nix-community/neovim-nightly-overlay/ce477ade892d794fd21725d0525bc45739fdf64e?narHash=sha256-%2BQUffIvhBPdJNPbTUPdheijA1eQeAHlgvJqZ0qMPL34%3D' (2024-09-03)
  → 'github:nix-community/neovim-nightly-overlay/370f8d7cd5610dfb6aa4c99aa1a34c9b17f7085a?narHash=sha256-DnUUKsVqyCfgdIEUQvOlL%2BD8zLqTCbFE5cA9mB/Yaj4%3D' (2025-03-09)
• Updated input 'neovim-flake/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33?narHash=sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U%3D' (2023-10-04)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
• Updated input 'neovim-flake/flake-parts':
    'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6?narHash=sha256-%2Bebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y%3D' (2024-09-01)
  → 'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9?narHash=sha256-%2Bu2UunDA4Cl5Fci3m7S643HzKmIDAe%2BfiXrLqYsR2fs%3D' (2025-03-07)
• Updated input 'neovim-flake/git-hooks':
    'github:cachix/git-hooks.nix/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6?narHash=sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk%3D' (2024-08-28)
  → 'github:cachix/git-hooks.nix/b5a62751225b2f62ff3147d0a334055ebadcd5cc?narHash=sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc%3D' (2025-03-07)
• Removed input 'neovim-flake/git-hooks/nixpkgs-stable'
• Updated input 'neovim-flake/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/dba4367b9a9d9615456c430a6d6af716f6e84cef?narHash=sha256-MHHrHasTngp7EYQOObHJ1a/IsRF%2BwodHqOckhH6uZbk%3D' (2024-08-29)
  → 'github:hercules-ci/hercules-ci-effects/06519cec8fb32d219006da6eacd255504a9996af?narHash=sha256-0CjCfbq0yHWexOrpO06e2WU1r5JAqR6ffy1zgM3NksI%3D' (2025-02-15)
• Updated input 'neovim-flake/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d?narHash=sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm%2BGpZNw%3D' (2024-04-01)
  → 'github:hercules-ci/flake-parts/32ea77a06711b758da0ad9bd6a844c5740a87abd?narHash=sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm%2BzmZ7vxbJdo%3D' (2025-02-01)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/ae9674704ac5586438f60c883e918d448ef0e237?narHash=sha256-tRRSljYBy1GxQGaCvSywtCSJ%2BOQa6clYilJLMxTe%2BnM%3D' (2024-09-02)
  → 'github:neovim/neovim/e02ee7410a6d04b32ec38af9f4ffdcf0798a0f0b?narHash=sha256-igPvhGYRyNGLQBlKCxDb4qGoznG8/E1mOVCG4aQyRQ4%3D' (2025-03-08)
• Added input 'neovim-flake/treefmt-nix':
    'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204?narHash=sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU%3D' (2025-02-17)
• Added input 'neovim-flake/treefmt-nix/nixpkgs':
    follows 'neovim-flake/nixpkgs'
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/55ab1e1df5daf2476e6b826b69a82862dcbd7544?narHash=sha256-AydPpRBh8%2BNOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8%3D' (2024-12-29)
  → 'github:nix-community/nix-index-database/296a2c992a28b37427d062ade6e20d467e479e3f?narHash=sha256-/tjVMbMzxJXrJaEk9N5esnbLebIZrkS1fbDJce/RiQg%3D' (2025-03-09)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef?narHash=sha256-UjpKo92iZ25M05kgSOw/Ti6VZwpgdlOa73zHj8OcaDk%3D' (2024-08-28)
  → 'github:nixos/nixos-hardware/b48cc4dab0f9711af296fc367b6108cf7b8ccb16?narHash=sha256-RUAdT8dZ6k/486vnu3tiNRrNW6%2BQ8uSD2Mq7gTX4jlo%3D' (2025-03-07)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b681065d0919f7eb5309a93cea2cfa84dec9aa88?narHash=sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek%3D' (2024-12-03)
  → 'github:nixos/nixpkgs/52e3095f6d812b91b22fb7ad0bfc1ab416453634?narHash=sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE%3D' (2025-03-08)
• Updated input 'nur':
    'github:nix-community/nur/8b7d030200a43ec6b2b794c94b6142709a231203?narHash=sha256-H0RJ9%2BpmXnUgdQzj4Hq45khxpkD8jKxgc3qMzxaTFqY%3D' (2024-09-03)
  → 'github:nix-community/nur/38c5768166682ff0805919f88f51c6f3cda39286?narHash=sha256-fSrT9YPEIUe7YR2YgkyDT0rq1RxOIhwH8YtygSlBcM4%3D' (2025-03-09)
• Added input 'nur/flake-parts':
    'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9?narHash=sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c%3D' (2024-12-04)
• Added input 'nur/flake-parts/nixpkgs-lib':
    follows 'nur/nixpkgs'
• Added input 'nur/nixpkgs':
    'github:nixos/nixpkgs/36fd87baa9083f34f7f5027900b62ee6d09b1f2f?narHash=sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw%3D' (2025-03-07)
• Added input 'nur/treefmt-nix':
    'github:numtide/treefmt-nix/49717b5af6f80172275d47a418c9719a31a78b53?narHash=sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM%3D' (2024-12-03)
• Added input 'nur/treefmt-nix/nixpkgs':
    follows 'nur/nixpkgs'
• Updated input 'nushell-src':
    'github:nushell/nushell/c150af42795d4078f0ea3b66eb1fe60d3373e510?narHash=sha256-mRq/9h/ItB16oO4ShYjXJ1PAWu5HrvoGhfVjpxUFqS8%3D' (2024-09-02)
  → 'github:nushell/nushell/d97b2e3c60167688f159f460c728155580eb380d?narHash=sha256-NxR6YbPcfUcBd5K5G2PqM9iHwHjNK2drFxJZh58Ysms%3D' (2025-03-09)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/2c19bad6e881b5a154cafb7f9106879b5b356d1f?narHash=sha256-WZ5rpjr/wCt7yBOUsvDE2i22hYz9g8W921jlwVktRQ4%3D' (2024-11-13)
  → 'github:oxalica/rust-overlay/d95582a900bd0e7e516ce3bed0503f742649fffb?narHash=sha256-3hrpyTLNmnJpioVT1DDoVgsp7fWYkuS3JWCtfHsX1rk%3D' (2025-03-09)

```

</p></details>

 - Removed input `ghostty/zig/flake-utils/systems`.
 - Updated input [`ghostty/flake-compat`](https://github.com/edolstra/flake-compat): [`0f9255e0` ➡️ `ff81ac96`](https://github.com/edolstra/flake-compat/compare/0f9255e01c2351cc7d116c072cb317785dd33b33...ff81ac966bb2cae68946d5ed5fc4994f96d0ffec) <sub>(2023-10-04 to 2024-12-04)</sub>
 - Added input `nur/treefmt-nix/nixpkgs`: ``
 - Updated input [`nur`](https://github.com/nix-community/nur): [`8b7d0302` ➡️ `38c57681`](https://github.com/nix-community/nur/compare/8b7d030200a43ec6b2b794c94b6142709a231203...38c5768166682ff0805919f88f51c6f3cda39286) <sub>(2024-09-03 to 2025-03-09)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`ae967470` ➡️ `e02ee741`](https://github.com/neovim/neovim/compare/ae9674704ac5586438f60c883e918d448ef0e237...e02ee7410a6d04b32ec38af9f4ffdcf0798a0f0b) <sub>(2024-09-02 to 2025-03-08)</sub>
 - Added input `ghostty/zig2nix/flake-utils`: ``
 - Added input [`ghostty/flake-utils/systems`](https://github.com/nix-systems/default): [github.com/nix-systems/default](https://github.com/nix-systems/default/tree/da67096a3b9bf56a91d16901293e51ba5b49a27e/)
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`7c4b53a7` ➡️ `adf5c88b`](https://github.com/lnl7/nix-darwin/compare/7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda...adf5c88ba1fe21af5c083b4d655004431f20c5ab) <sub>(2024-09-01 to 2025-03-06)</sub>
 - Updated input [`neovim-flake/flake-compat`](https://github.com/edolstra/flake-compat): [`0f9255e0` ➡️ `ff81ac96`](https://github.com/edolstra/flake-compat/compare/0f9255e01c2351cc7d116c072cb317785dd33b33...ff81ac966bb2cae68946d5ed5fc4994f96d0ffec) <sub>(2023-10-04 to 2024-12-04)</sub>
 - Updated input [`nix-index-database`](https://github.com/nix-community/nix-index-database): [`55ab1e1d` ➡️ `296a2c99`](https://github.com/nix-community/nix-index-database/compare/55ab1e1df5daf2476e6b826b69a82862dcbd7544...296a2c992a28b37427d062ade6e20d467e479e3f) <sub>(2024-12-29 to 2025-03-09)</sub>
 - Added input `neovim-flake/treefmt-nix/nixpkgs`: ``
 - Added input [`neovim-flake/treefmt-nix`](https://github.com/numtide/treefmt-nix): [github.com/numtide/treefmt-nix](https://github.com/numtide/treefmt-nix/tree/3d0579f5cc93436052d94b73925b48973a104204/)
 - Updated input [`neovim-flake/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`dba4367b` ➡️ `06519cec`](https://github.com/hercules-ci/hercules-ci-effects/compare/dba4367b9a9d9615456c430a6d6af716f6e84cef...06519cec8fb32d219006da6eacd255504a9996af) <sub>(2024-08-29 to 2025-02-15)</sub>
 - Updated input [`neovim-flake/git-hooks`](https://github.com/cachix/git-hooks.nix): [`4509ca64` ➡️ `b5a62751`](https://github.com/cachix/git-hooks.nix/compare/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6...b5a62751225b2f62ff3147d0a334055ebadcd5cc) <sub>(2024-08-28 to 2025-03-07)</sub>
 - Added input [`nur/treefmt-nix`](https://github.com/numtide/treefmt-nix): [github.com/numtide/treefmt-nix](https://github.com/numtide/treefmt-nix/tree/49717b5af6f80172275d47a418c9719a31a78b53/)
 - Added input [`nur/nixpkgs`](https://github.com/nixos/nixpkgs): [github.com/nixos/nixpkgs](https://github.com/nixos/nixpkgs/tree/36fd87baa9083f34f7f5027900b62ee6d09b1f2f/)
 - Added input [`ghostty/flake-utils`](https://github.com/numtide/flake-utils): [github.com/numtide/flake-utils](https://github.com/numtide/flake-utils/tree/11707dc2f618dd54ca8739b309ec4fc024de578b/)
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`b681065d` ➡️ `52e3095f`](https://github.com/nixos/nixpkgs/compare/b681065d0919f7eb5309a93cea2cfa84dec9aa88...52e3095f6d812b91b22fb7ad0bfc1ab416453634) <sub>(2024-12-03 to 2025-03-08)</sub>
 - Updated input [`neovim-flake/flake-parts`](https://github.com/hercules-ci/flake-parts): [`567b938d` ➡️ `f4330d22`](https://github.com/hercules-ci/flake-parts/compare/567b938d64d4b4112ee253b9274472dc3a346eb6...f4330d22f1c5d2ba72d3d22df5597d123fdb60a9) <sub>(2024-09-01 to 2025-03-07)</sub>
 - Added input `ghostty/zig2nix/nixpkgs`: ``
 - Updated input [`ghostty/zig`](https://github.com/mitchellh/zig-overlay): [`02fc5cc5` ➡️ `1a8fb6f3`](https://github.com/mitchellh/zig-overlay/compare/02fc5cc555fc14fda40c42d7c3250efa43812b43...1a8fb6f3a04724519436355564b95fce5e272504) <sub>(2024-06-08 to 2025-01-30)</sub>
 - Updated input [`ghostty/nixpkgs-stable`](https://github.com/nixos/nixpkgs): [`e36963a1` ➡️ `c3511a3b`](https://github.com/nixos/nixpkgs/compare/e36963a147267afc055f7cf65225958633e536bf...c3511a3b53b482aa7547c9d1626fd7310c1de1c5) <sub>(2024-12-05 to 2025-01-30)</sub>
 - Updated input [`ghostty`](https://github.com/ghostty-org/ghostty): [`6cbd69da` ➡️ `843cc83f`](https://github.com/ghostty-org/ghostty/compare/6cbd69da7839260508466f9dfb2bc0c0fbb43991...843cc83f42a9677bb998b8b16a00aac68e6f53aa) <sub>(2024-12-28 to 2025-03-09)</sub>
 - Updated input [`flake-compat`](https://github.com/edolstra/flake-compat): [`0f9255e0` ➡️ `ff81ac96`](https://github.com/edolstra/flake-compat/compare/0f9255e01c2351cc7d116c072cb317785dd33b33...ff81ac966bb2cae68946d5ed5fc4994f96d0ffec) <sub>(2023-10-04 to 2024-12-04)</sub>
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`ce477ade` ➡️ `370f8d7c`](https://github.com/nix-community/neovim-nightly-overlay/compare/ce477ade892d794fd21725d0525bc45739fdf64e...370f8d7cd5610dfb6aa4c99aa1a34c9b17f7085a) <sub>(2024-09-03 to 2025-03-09)</sub>
 - Added input [`ghostty/zig2nix`](https://github.com/jcollie/zig2nix): [github.com/jcollie/zig2nix](https://github.com/jcollie/zig2nix/tree/672971b5b6911de21446ad4fc76dee677922eda0/)
 - Added input [`nur/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9/)
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`2c19bad6` ➡️ `d95582a9`](https://github.com/oxalica/rust-overlay/compare/2c19bad6e881b5a154cafb7f9106879b5b356d1f...d95582a900bd0e7e516ce3bed0503f742649fffb) <sub>(2024-11-13 to 2025-03-09)</sub>
 - Removed input `neovim-flake/git-hooks/nixpkgs-stable`.
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`62d53625` ➡️ `9d3d080a`](https://github.com/nix-community/home-manager/compare/62d536255879be574ebfe9b87c4ac194febf47c5...9d3d080aec2a35e05a15cedd281c2384767c2cfe) <sub>(2024-12-01 to 2025-02-17)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`c150af42` ➡️ `d97b2e3c`](https://github.com/nushell/nushell/compare/c150af42795d4078f0ea3b66eb1fe60d3373e510...d97b2e3c60167688f159f460c728155580eb380d) <sub>(2024-09-02 to 2025-03-09)</sub>
 - Added input `nur/flake-parts/nixpkgs-lib`: ``
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`95c3dfe6` ➡️ `b48cc4da`](https://github.com/nixos/nixos-hardware/compare/95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef...b48cc4dab0f9711af296fc367b6108cf7b8ccb16) <sub>(2024-08-28 to 2025-03-07)</sub>
 - Updated input [`neovim-flake/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9126214d` ➡️ `32ea77a0`](https://github.com/hercules-ci/flake-parts/compare/9126214d0a59633752a136528f5f3b9aa8565b7d...32ea77a06711b758da0ad9bd6a844c5740a87abd) <sub>(2024-04-01 to 2025-02-01)</sub>
 - Updated input `ghostty/zig/flake-utils`: `1ef2e671` ➡️ `` <sub>(2024-01-15 to )</sub>
 - Updated input [`ghostty/nixpkgs-unstable`](https://github.com/nixos/nixpkgs): [`566e53c2` ➡️ `9a5db314`](https://github.com/nixos/nixpkgs/compare/566e53c2ad750c84f6d31f9ccb9d00f823165550...9a5db3142ce450045840cc8d832b13b8a2018e0c) <sub>(2024-12-03 to 2025-01-29)</sub>