### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741229100,
-        "narHash": "sha256-0HwrTDXp9buEwal/1ymK9uQmzUD5ozIA7CJGqnT/gLs=",
+        "lastModified": 1743350051,
+        "narHash": "sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "adf5c88ba1fe21af5c083b4d655004431f20c5ab",
+        "rev": "eaff8219d629bb86e71e3274e1b7915014e7fb22",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -173,14 +173,14 @@
         "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "zig": "zig",
-        "zig2nix": "zig2nix"
+        "zon2nix": "zon2nix"
       },
       "locked": {
-        "lastModified": 1741531864,
-        "narHash": "sha256-PXpsBVZ7plbjoJCUKCh6yBAS7c+OT7RZXjU3YsrypkI=",
+        "lastModified": 1743191728,
+        "narHash": "sha256-LrQd2IkfcmHdBh+pwPEPXzcosBerIEFzz/DbVNzBqig=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "843cc83f42a9677bb998b8b16a00aac68e6f53aa",
+        "rev": "1067cd3d8a061eb5b23bc1a4c46ca10af4481941",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741379162,
-        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739595404,
-        "narHash": "sha256-0CjCfbq0yHWexOrpO06e2WU1r5JAqR6ffy1zgM3NksI=",
+        "lastModified": 1742014779,
+        "narHash": "sha256-I6fG1zrfdLFcp/imGZElig0BJO3YU0QEXLgvwWoOpJ8=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "06519cec8fb32d219006da6eacd255504a9996af",
+        "rev": "524637ef84c177661690b924bf64a1ce18072a2c",
         "type": "github"
       },
       "original": {
@@ -263,11 +263,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739757849,
-        "narHash": "sha256-Gs076ot1YuAAsYVcyidLKUMIc4ooOaRGO0PqTY7sBzA=",
+        "lastModified": 1743387206,
+        "narHash": "sha256-24N3NAuZZbYqZ39NgToZgHUw6M7xHrtrAm18kv0+2Wo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9d3d080aec2a35e05a15cedd281c2384767c2cfe",
+        "rev": "15c5f9d04fabd176f30286c8f52bbdb2c853a146",
         "type": "github"
       },
       "original": {
@@ -290,11 +290,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1741531860,
-        "narHash": "sha256-DnUUKsVqyCfgdIEUQvOlL+D8zLqTCbFE5cA9mB/Yaj4=",
+        "lastModified": 1743398899,
+        "narHash": "sha256-gJeoWpWv14MnLoiERpVhHWSDzujvg9UM2BvR7BZe6AI=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "370f8d7cd5610dfb6aa4c99aa1a34c9b17f7085a",
+        "rev": "4be99133c03920579de8c3fe7c05ff1de60a7fbe",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1741473351,
-        "narHash": "sha256-igPvhGYRyNGLQBlKCxDb4qGoznG8/E1mOVCG4aQyRQ4=",
+        "lastModified": 1743368881,
+        "narHash": "sha256-CRORP8EaJ/Ajdx6WbUSjt9X4zNToyDLkzWz6VIthsaA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "e02ee7410a6d04b32ec38af9f4ffdcf0798a0f0b",
+        "rev": "ee143aaf65a0e662c42c636aa4a959682858b3e7",
         "type": "github"
       },
       "original": {
@@ -326,11 +326,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741490098,
-        "narHash": "sha256-/tjVMbMzxJXrJaEk9N5esnbLebIZrkS1fbDJce/RiQg=",
+        "lastModified": 1743306489,
+        "narHash": "sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "296a2c992a28b37427d062ade6e20d467e479e3f",
+        "rev": "b3696bfb6c24aa61428839a99e8b40c53ac3a82d",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1741325094,
-        "narHash": "sha256-RUAdT8dZ6k/486vnu3tiNRrNW6+Q8uSD2Mq7gTX4jlo=",
+        "lastModified": 1743420942,
+        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "b48cc4dab0f9711af296fc367b6108cf7b8ccb16",
+        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741445498,
-        "narHash": "sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE=",
+        "lastModified": 1743367904,
+        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52e3095f6d812b91b22fb7ad0bfc1ab416453634",
+        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
         "type": "github"
       },
       "original": {
@@ -372,11 +372,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1738255539,
-        "narHash": "sha256-hP2eOqhIO/OILW+3moNWO4GtdJFYCqAe9yJZgvlCoDQ=",
+        "lastModified": 1741992157,
+        "narHash": "sha256-nlIfTsTrMSksEJc1f7YexXiPVuzD1gOfeN1ggwZyUoc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c3511a3b53b482aa7547c9d1626fd7310c1de1c5",
+        "rev": "da4b122f63095ca1199bd4d526f9e26426697689",
         "type": "github"
       },
       "original": {
@@ -388,11 +388,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1738136902,
-        "narHash": "sha256-pUvLijVGARw4u793APze3j6mU1Zwdtz7hGkGGkD87qw=",
+        "lastModified": 1741865919,
+        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9a5db3142ce450045840cc8d832b13b8a2018e0c",
+        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
         "type": "github"
       },
       "original": {
@@ -404,11 +404,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741379970,
-        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {
@@ -425,11 +425,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1741556705,
-        "narHash": "sha256-fSrT9YPEIUe7YR2YgkyDT0rq1RxOIhwH8YtygSlBcM4=",
+        "lastModified": 1743454066,
+        "narHash": "sha256-8h+Ne6XNccuvkS6ZvcK7yTc+so35J2KvIOPAipFdM7o=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "38c5768166682ff0805919f88f51c6f3cda39286",
+        "rev": "0d287e4ac4f1572a4d615b46c17365ac1846dfdf",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1741552982,
-        "narHash": "sha256-NxR6YbPcfUcBd5K5G2PqM9iHwHjNK2drFxJZh58Ysms=",
+        "lastModified": 1743462183,
+        "narHash": "sha256-whrLa4r+CpyL2RRof4WZIvI28oAOnPvmBsHmO8/d+Uc=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "d97b2e3c60167688f159f460c728155580eb380d",
+        "rev": "1dcaffb79272b87f84a4b103f361d0fda6f8af9f",
         "type": "github"
       },
       "original": {
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741486734,
-        "narHash": "sha256-3hrpyTLNmnJpioVT1DDoVgsp7fWYkuS3JWCtfHsX1rk=",
+        "lastModified": 1743388531,
+        "narHash": "sha256-OBcNE+2/TD1AMgq8HKMotSQF8ZPJEFGZdRoBJ7t/HIc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d95582a900bd0e7e516ce3bed0503f742649fffb",
+        "rev": "011de3c895927300651d9c2cb8e062adf17aa665",
         "type": "github"
       },
       "original": {
@@ -512,11 +512,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1743081648,
+        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
         "type": "github"
       },
       "original": {
@@ -561,11 +561,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738239110,
-        "narHash": "sha256-Y5i9mQ++dyIQr+zEPNy+KIbc5wjPmfllBrag3cHZgcE=",
+        "lastModified": 1741825901,
+        "narHash": "sha256-aeopo+aXg5I2IksOPFN79usw7AeimH1+tjfuMzJHFdk=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "1a8fb6f3a04724519436355564b95fce5e272504",
+        "rev": "0b14285e283f5a747f372fb2931835dd937c4383",
         "type": "github"
       },
       "original": {
@@ -574,7 +574,7 @@
         "type": "github"
       }
     },
-    "zig2nix": {
+    "zon2nix": {
       "inputs": {
         "flake-utils": [
           "ghostty",
@@ -582,21 +582,21 @@
         ],
         "nixpkgs": [
           "ghostty",
-          "nixpkgs-stable"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {
-        "lastModified": 1741368279,
-        "narHash": "sha256-WTaC8HmnIq6O71iK0g9as404BbmS+YyEP5qS85m2JBY=",
+        "lastModified": 1742104771,
+        "narHash": "sha256-LhidlyEA9MP8jGe1rEnyjGFCzLLgCdDpYeWggibayr0=",
         "owner": "jcollie",
-        "repo": "zig2nix",
-        "rev": "672971b5b6911de21446ad4fc76dee677922eda0",
+        "repo": "zon2nix",
+        "rev": "56c159be489cc6c0e73c3930bd908ddc6fe89613",
         "type": "github"
       },
       "original": {
         "owner": "jcollie",
-        "ref": "672971b5b6911de21446ad4fc76dee677922eda0",
-        "repo": "zig2nix",
+        "ref": "56c159be489cc6c0e73c3930bd908ddc6fe89613",
+        "repo": "zon2nix",
         "type": "github"
       }
     }


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/adf5c88ba1fe21af5c083b4d655004431f20c5ab?narHash=sha256-0HwrTDXp9buEwal/1ymK9uQmzUD5ozIA7CJGqnT/gLs%3D' (2025-03-06)
  → 'github:lnl7/nix-darwin/eaff8219d629bb86e71e3274e1b7915014e7fb22?narHash=sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk%3D' (2025-03-30)
• Updated input 'ghostty':
    'github:ghostty-org/ghostty/843cc83f42a9677bb998b8b16a00aac68e6f53aa?narHash=sha256-PXpsBVZ7plbjoJCUKCh6yBAS7c%2BOT7RZXjU3YsrypkI%3D' (2025-03-09)
  → 'github:ghostty-org/ghostty/1067cd3d8a061eb5b23bc1a4c46ca10af4481941?narHash=sha256-LrQd2IkfcmHdBh%2BpwPEPXzcosBerIEFzz/DbVNzBqig%3D' (2025-03-28)
• Updated input 'ghostty/nixpkgs-stable':
    'github:nixos/nixpkgs/c3511a3b53b482aa7547c9d1626fd7310c1de1c5?narHash=sha256-hP2eOqhIO/OILW%2B3moNWO4GtdJFYCqAe9yJZgvlCoDQ%3D' (2025-01-30)
  → 'github:nixos/nixpkgs/da4b122f63095ca1199bd4d526f9e26426697689?narHash=sha256-nlIfTsTrMSksEJc1f7YexXiPVuzD1gOfeN1ggwZyUoc%3D' (2025-03-14)
• Updated input 'ghostty/nixpkgs-unstable':
    'github:nixos/nixpkgs/9a5db3142ce450045840cc8d832b13b8a2018e0c?narHash=sha256-pUvLijVGARw4u793APze3j6mU1Zwdtz7hGkGGkD87qw%3D' (2025-01-29)
  → 'github:nixos/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a?narHash=sha256-4thdbnP6dlbdq%2BqZWTsm4ffAwoS8Tiq1YResB%2BRP6WE%3D' (2025-03-13)
• Updated input 'ghostty/zig':
    'github:mitchellh/zig-overlay/1a8fb6f3a04724519436355564b95fce5e272504?narHash=sha256-Y5i9mQ%2B%2BdyIQr%2BzEPNy%2BKIbc5wjPmfllBrag3cHZgcE%3D' (2025-01-30)
  → 'github:mitchellh/zig-overlay/0b14285e283f5a747f372fb2931835dd937c4383?narHash=sha256-aeopo%2BaXg5I2IksOPFN79usw7AeimH1%2BtjfuMzJHFdk%3D' (2025-03-13)
• Removed input 'ghostty/zig2nix'
• Removed input 'ghostty/zig2nix/flake-utils'
• Removed input 'ghostty/zig2nix/nixpkgs'
• Added input 'ghostty/zon2nix':
    'github:jcollie/zon2nix/56c159be489cc6c0e73c3930bd908ddc6fe89613?narHash=sha256-LhidlyEA9MP8jGe1rEnyjGFCzLLgCdDpYeWggibayr0%3D' (2025-03-16)
• Added input 'ghostty/zon2nix/flake-utils':
    follows 'ghostty/flake-utils'
• Added input 'ghostty/zon2nix/nixpkgs':
    follows 'ghostty/nixpkgs-unstable'
• Updated input 'home-manager':
    'github:nix-community/home-manager/9d3d080aec2a35e05a15cedd281c2384767c2cfe?narHash=sha256-Gs076ot1YuAAsYVcyidLKUMIc4ooOaRGO0PqTY7sBzA%3D' (2025-02-17)
  → 'github:nix-community/home-manager/15c5f9d04fabd176f30286c8f52bbdb2c853a146?narHash=sha256-24N3NAuZZbYqZ39NgToZgHUw6M7xHrtrAm18kv0%2B2Wo%3D' (2025-03-31)
• Updated input 'neovim-flake':
    'github:nix-community/neovim-nightly-overlay/370f8d7cd5610dfb6aa4c99aa1a34c9b17f7085a?narHash=sha256-DnUUKsVqyCfgdIEUQvOlL%2BD8zLqTCbFE5cA9mB/Yaj4%3D' (2025-03-09)
  → 'github:nix-community/neovim-nightly-overlay/4be99133c03920579de8c3fe7c05ff1de60a7fbe?narHash=sha256-gJeoWpWv14MnLoiERpVhHWSDzujvg9UM2BvR7BZe6AI%3D' (2025-03-31)
• Updated input 'neovim-flake/git-hooks':
    'github:cachix/git-hooks.nix/b5a62751225b2f62ff3147d0a334055ebadcd5cc?narHash=sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc%3D' (2025-03-07)
  → 'github:cachix/git-hooks.nix/dcf5072734cb576d2b0c59b2ac44f5050b5eac82?narHash=sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco%3D' (2025-03-22)
• Updated input 'neovim-flake/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/06519cec8fb32d219006da6eacd255504a9996af?narHash=sha256-0CjCfbq0yHWexOrpO06e2WU1r5JAqR6ffy1zgM3NksI%3D' (2025-02-15)
  → 'github:hercules-ci/hercules-ci-effects/524637ef84c177661690b924bf64a1ce18072a2c?narHash=sha256-I6fG1zrfdLFcp/imGZElig0BJO3YU0QEXLgvwWoOpJ8%3D' (2025-03-15)
• Updated input 'neovim-flake/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/32ea77a06711b758da0ad9bd6a844c5740a87abd?narHash=sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm%2BzmZ7vxbJdo%3D' (2025-02-01)
  → 'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9?narHash=sha256-%2Bu2UunDA4Cl5Fci3m7S643HzKmIDAe%2BfiXrLqYsR2fs%3D' (2025-03-07)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/e02ee7410a6d04b32ec38af9f4ffdcf0798a0f0b?narHash=sha256-igPvhGYRyNGLQBlKCxDb4qGoznG8/E1mOVCG4aQyRQ4%3D' (2025-03-08)
  → 'github:neovim/neovim/ee143aaf65a0e662c42c636aa4a959682858b3e7?narHash=sha256-CRORP8EaJ/Ajdx6WbUSjt9X4zNToyDLkzWz6VIthsaA%3D' (2025-03-30)
• Updated input 'neovim-flake/treefmt-nix':
    'github:numtide/treefmt-nix/3d0579f5cc93436052d94b73925b48973a104204?narHash=sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU%3D' (2025-02-17)
  → 'github:numtide/treefmt-nix/29a3d7b768c70addce17af0869f6e2bd8f5be4b7?narHash=sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE%3D' (2025-03-27)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/296a2c992a28b37427d062ade6e20d467e479e3f?narHash=sha256-/tjVMbMzxJXrJaEk9N5esnbLebIZrkS1fbDJce/RiQg%3D' (2025-03-09)
  → 'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d?narHash=sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E%3D' (2025-03-30)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/b48cc4dab0f9711af296fc367b6108cf7b8ccb16?narHash=sha256-RUAdT8dZ6k/486vnu3tiNRrNW6%2BQ8uSD2Mq7gTX4jlo%3D' (2025-03-07)
  → 'github:nixos/nixos-hardware/de6fc5551121c59c01e2a3d45b277a6d05077bc4?narHash=sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo%3D' (2025-03-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/52e3095f6d812b91b22fb7ad0bfc1ab416453634?narHash=sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE%3D' (2025-03-08)
  → 'github:nixos/nixpkgs/7ffe0edc685f14b8c635e3d6591b0bbb97365e6c?narHash=sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI%3D' (2025-03-30)
• Updated input 'nur':
    'github:nix-community/nur/38c5768166682ff0805919f88f51c6f3cda39286?narHash=sha256-fSrT9YPEIUe7YR2YgkyDT0rq1RxOIhwH8YtygSlBcM4%3D' (2025-03-09)
  → 'github:nix-community/nur/0d287e4ac4f1572a4d615b46c17365ac1846dfdf?narHash=sha256-8h%2BNe6XNccuvkS6ZvcK7yTc%2Bso35J2KvIOPAipFdM7o%3D' (2025-03-31)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/36fd87baa9083f34f7f5027900b62ee6d09b1f2f?narHash=sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw%3D' (2025-03-07)
  → 'github:nixos/nixpkgs/52faf482a3889b7619003c0daec593a1912fddc1?narHash=sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om%2BD4UnDhlDW9BE%3D' (2025-03-30)
• Updated input 'nushell-src':
    'github:nushell/nushell/d97b2e3c60167688f159f460c728155580eb380d?narHash=sha256-NxR6YbPcfUcBd5K5G2PqM9iHwHjNK2drFxJZh58Ysms%3D' (2025-03-09)
  → 'github:nushell/nushell/1dcaffb79272b87f84a4b103f361d0fda6f8af9f?narHash=sha256-whrLa4r%2BCpyL2RRof4WZIvI28oAOnPvmBsHmO8/d%2BUc%3D' (2025-03-31)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/d95582a900bd0e7e516ce3bed0503f742649fffb?narHash=sha256-3hrpyTLNmnJpioVT1DDoVgsp7fWYkuS3JWCtfHsX1rk%3D' (2025-03-09)
  → 'github:oxalica/rust-overlay/011de3c895927300651d9c2cb8e062adf17aa665?narHash=sha256-OBcNE%2B2/TD1AMgq8HKMotSQF8ZPJEFGZdRoBJ7t/HIc%3D' (2025-03-31)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`38c57681` ➡️ `0d287e4a`](https://github.com/nix-community/nur/compare/38c5768166682ff0805919f88f51c6f3cda39286...0d287e4ac4f1572a4d615b46c17365ac1846dfdf) <sub>(2025-03-09 to 2025-03-31)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`e02ee741` ➡️ `ee143aaf`](https://github.com/neovim/neovim/compare/e02ee7410a6d04b32ec38af9f4ffdcf0798a0f0b...ee143aaf65a0e662c42c636aa4a959682858b3e7) <sub>(2025-03-08 to 2025-03-30)</sub>
 - Removed input `ghostty/zig2nix/flake-utils`.
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`adf5c88b` ➡️ `eaff8219`](https://github.com/lnl7/nix-darwin/compare/adf5c88ba1fe21af5c083b4d655004431f20c5ab...eaff8219d629bb86e71e3274e1b7915014e7fb22) <sub>(2025-03-06 to 2025-03-30)</sub>
 - Added input `ghostty/zon2nix/nixpkgs`: ``
 - Updated input [`nix-index-database`](https://github.com/nix-community/nix-index-database): [`296a2c99` ➡️ `b3696bfb`](https://github.com/nix-community/nix-index-database/compare/296a2c992a28b37427d062ade6e20d467e479e3f...b3696bfb6c24aa61428839a99e8b40c53ac3a82d) <sub>(2025-03-09 to 2025-03-30)</sub>
 - Updated input [`neovim-flake/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`3d0579f5` ➡️ `29a3d7b7`](https://github.com/numtide/treefmt-nix/compare/3d0579f5cc93436052d94b73925b48973a104204...29a3d7b768c70addce17af0869f6e2bd8f5be4b7) <sub>(2025-02-17 to 2025-03-27)</sub>
 - Updated input [`neovim-flake/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`06519cec` ➡️ `524637ef`](https://github.com/hercules-ci/hercules-ci-effects/compare/06519cec8fb32d219006da6eacd255504a9996af...524637ef84c177661690b924bf64a1ce18072a2c) <sub>(2025-02-15 to 2025-03-15)</sub>
 - Updated input [`neovim-flake/git-hooks`](https://github.com/cachix/git-hooks.nix): [`b5a62751` ➡️ `dcf50727`](https://github.com/cachix/git-hooks.nix/compare/b5a62751225b2f62ff3147d0a334055ebadcd5cc...dcf5072734cb576d2b0c59b2ac44f5050b5eac82) <sub>(2025-03-07 to 2025-03-22)</sub>
 - Updated input [`nur/nixpkgs`](https://github.com/nixos/nixpkgs): [`36fd87ba` ➡️ `52faf482`](https://github.com/nixos/nixpkgs/compare/36fd87baa9083f34f7f5027900b62ee6d09b1f2f...52faf482a3889b7619003c0daec593a1912fddc1) <sub>(2025-03-07 to 2025-03-30)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`52e3095f` ➡️ `7ffe0edc`](https://github.com/nixos/nixpkgs/compare/52e3095f6d812b91b22fb7ad0bfc1ab416453634...7ffe0edc685f14b8c635e3d6591b0bbb97365e6c) <sub>(2025-03-08 to 2025-03-30)</sub>
 - Removed input `ghostty/zig2nix/nixpkgs`.
 - Updated input [`ghostty/zig`](https://github.com/mitchellh/zig-overlay): [`1a8fb6f3` ➡️ `0b14285e`](https://github.com/mitchellh/zig-overlay/compare/1a8fb6f3a04724519436355564b95fce5e272504...0b14285e283f5a747f372fb2931835dd937c4383) <sub>(2025-01-30 to 2025-03-13)</sub>
 - Updated input [`ghostty/nixpkgs-stable`](https://github.com/nixos/nixpkgs): [`c3511a3b` ➡️ `da4b122f`](https://github.com/nixos/nixpkgs/compare/c3511a3b53b482aa7547c9d1626fd7310c1de1c5...da4b122f63095ca1199bd4d526f9e26426697689) <sub>(2025-01-30 to 2025-03-14)</sub>
 - Updated input [`ghostty`](https://github.com/ghostty-org/ghostty): [`843cc83f` ➡️ `1067cd3d`](https://github.com/ghostty-org/ghostty/compare/843cc83f42a9677bb998b8b16a00aac68e6f53aa...1067cd3d8a061eb5b23bc1a4c46ca10af4481941) <sub>(2025-03-09 to 2025-03-28)</sub>
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`370f8d7c` ➡️ `4be99133`](https://github.com/nix-community/neovim-nightly-overlay/compare/370f8d7cd5610dfb6aa4c99aa1a34c9b17f7085a...4be99133c03920579de8c3fe7c05ff1de60a7fbe) <sub>(2025-03-09 to 2025-03-31)</sub>
 - Removed input `ghostty/zig2nix`.
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`d95582a9` ➡️ `011de3c8`](https://github.com/oxalica/rust-overlay/compare/d95582a900bd0e7e516ce3bed0503f742649fffb...011de3c895927300651d9c2cb8e062adf17aa665) <sub>(2025-03-09 to 2025-03-31)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`9d3d080a` ➡️ `15c5f9d0`](https://github.com/nix-community/home-manager/compare/9d3d080aec2a35e05a15cedd281c2384767c2cfe...15c5f9d04fabd176f30286c8f52bbdb2c853a146) <sub>(2025-02-17 to 2025-03-31)</sub>
 - Added input `ghostty/zon2nix/flake-utils`: ``
 - Added input [`ghostty/zon2nix`](https://github.com/jcollie/zon2nix): [github.com/jcollie/zon2nix](https://github.com/jcollie/zon2nix/tree/56c159be489cc6c0e73c3930bd908ddc6fe89613/)
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`d97b2e3c` ➡️ `1dcaffb7`](https://github.com/nushell/nushell/compare/d97b2e3c60167688f159f460c728155580eb380d...1dcaffb79272b87f84a4b103f361d0fda6f8af9f) <sub>(2025-03-09 to 2025-03-31)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`b48cc4da` ➡️ `de6fc555`](https://github.com/nixos/nixos-hardware/compare/b48cc4dab0f9711af296fc367b6108cf7b8ccb16...de6fc5551121c59c01e2a3d45b277a6d05077bc4) <sub>(2025-03-07 to 2025-03-31)</sub>
 - Updated input [`neovim-flake/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [`32ea77a0` ➡️ `f4330d22`](https://github.com/hercules-ci/flake-parts/compare/32ea77a06711b758da0ad9bd6a844c5740a87abd...f4330d22f1c5d2ba72d3d22df5597d123fdb60a9) <sub>(2025-02-01 to 2025-03-07)</sub>
 - Updated input [`ghostty/nixpkgs-unstable`](https://github.com/nixos/nixpkgs): [`9a5db314` ➡️ `573c650e`](https://github.com/nixos/nixpkgs/compare/9a5db3142ce450045840cc8d832b13b8a2018e0c...573c650e8a14b2faa0041645ab18aed7e60f0c9a) <sub>(2025-01-29 to 2025-03-13)</sub>