### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743496612,
-        "narHash": "sha256-emPWa5lmKbnyuj8c1mSJUkzJNT+iJoU9GMcXwjp2oVM=",
+        "lastModified": 1744478979,
+        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "73d59580d01e9b9f957ba749f336a272869c42dd",
+        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
         "zon2nix": "zon2nix"
       },
       "locked": {
-        "lastModified": 1743820100,
-        "narHash": "sha256-URg5DLo0IvpTLNGrWA9f6U4pl21JxsQWSJUpjvALyxs=",
+        "lastModified": 1744671375,
+        "narHash": "sha256-flGMRT7E4URVCj0o4bMfQlehJNrD/1mZy4OobfEwvq8=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "6f7977fef186faa9b9afe7707dc21a2eff59883b",
+        "rev": "4aa875bbf641d9c31619217b3dc373d734986247",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742014779,
-        "narHash": "sha256-I6fG1zrfdLFcp/imGZElig0BJO3YU0QEXLgvwWoOpJ8=",
+        "lastModified": 1744624138,
+        "narHash": "sha256-PWcxJN2MoWCGC73KI93di2njqrashftWJ6w/fWTvdCM=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "524637ef84c177661690b924bf64a1ce18072a2c",
+        "rev": "6eaa505af87705041ef2cf5534f5fc8fe88e94c2",
         "type": "github"
       },
       "original": {
@@ -263,11 +263,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743808813,
-        "narHash": "sha256-2lDQBOmlz9ggPxcS7/GvcVdzXMIiT+PpMao6FbLJSr0=",
+        "lastModified": 1744117652,
+        "narHash": "sha256-t7dFCDl4vIOOUMhEZnJF15aAzkpaup9x4ZRGToDFYWI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9f8b3db211b4609ddd83683f9db89796c7f6ac6",
+        "rev": "b4e98224ad1336751a2ac7493967a4c9f6d9cb3f",
         "type": "github"
       },
       "original": {
@@ -290,11 +290,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1743825774,
-        "narHash": "sha256-7sh2G01stnOdDHCcy1ELXeEGrQaCEQ5FH5cgkVr9G+8=",
+        "lastModified": 1744675686,
+        "narHash": "sha256-633XUO9ScY38cZUpgwLo5FylImxDYZvErh54CAfQSsc=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "8c5c5d1c160110b186b1d6fe9c7302a82369d5f9",
+        "rev": "0d7c64d83bf26019292db406f1bfc62fb5f2bc3f",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1743773673,
-        "narHash": "sha256-Tg/bzD2vBjavOS4jUMQV60dwg5RzSpFsjQr/C3xbq9g=",
+        "lastModified": 1744629547,
+        "narHash": "sha256-N/1NGAhjLg68kJJpdcccMbOkHZy0YY0HKnhs6TDDWU0=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a8edf6e4459d7422c1a96e4f33e350090902dc61",
+        "rev": "3341ab07764e9cda95e89880da579ea3ebb7f9b7",
         "type": "github"
       },
       "original": {
@@ -326,11 +326,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743306489,
-        "narHash": "sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E=",
+        "lastModified": 1744518957,
+        "narHash": "sha256-RLBSWQfTL0v+7uyskC5kP6slLK1jvIuhaAh8QvB75m4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "b3696bfb6c24aa61428839a99e8b40c53ac3a82d",
+        "rev": "4fc9ea78c962904f4ea11046f3db37c62e8a02fd",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1743420942,
-        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
+        "lastModified": 1744633460,
+        "narHash": "sha256-fbWE4Xpw6eH0Q6in+ymNuDwTkqmFmtxcQEmtRuKDTTk=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
+        "rev": "9a049b4a421076d27fee3eec664a18b2066824cb",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743703532,
-        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
         "type": "github"
       },
       "original": {
@@ -404,11 +404,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {
@@ -425,11 +425,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1743867911,
-        "narHash": "sha256-E1JS+GEkoPo9fgOE5E+b5V7c1cq3OBDuaI9Kg6DRkHk=",
+        "lastModified": 1744665912,
+        "narHash": "sha256-NRiuDkoCFap4GKb4UjtNqY2p6xnZl4/tRsPsP2m0kdg=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "67f21fa057f77a3c2450df19165db7d56e8896ae",
+        "rev": "a0fd02eb827911d886114c9f2680df34ec0a6267",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1743863056,
-        "narHash": "sha256-fAKeSvtO0fgyqwLDyzI50pIThO6ClPqYOEXL2W5+wHM=",
+        "lastModified": 1744675012,
+        "narHash": "sha256-e2Y+62kZ/5XXz7yubKkSKJnzFjjucdDxKvykmsoouB4=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "f25525be6cc0343d77f232f8ccecde25798d56aa",
+        "rev": "4e307480e4a5431053aa95750a733651c0200c59",
         "type": "github"
       },
       "original": {
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743820323,
-        "narHash": "sha256-UXxJogXhPhBFaX4uxmMudcD/x3sEGFtoSc4busTcftY=",
+        "lastModified": 1744599145,
+        "narHash": "sha256-yzaDPkJwZdUtRj/dzdOeB74yryWzpngYaD7BedqFKk8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b4734ce867252f92cdc7d25f8cc3b7cef153e703",
+        "rev": "fd6795d3d28f956de01a0458b6fa7baae5c793b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:lnl7/nix-darwin/73d59580d01e9b9f957ba749f336a272869c42dd?narHash=sha256-emPWa5lmKbnyuj8c1mSJUkzJNT%2BiJoU9GMcXwjp2oVM%3D' (2025-04-01)
  → 'github:lnl7/nix-darwin/43975d782b418ebf4969e9ccba82466728c2851b?narHash=sha256-dyN%2BteG9G82G%2Bm%2BPX/aSAagkC%2BvUv0SgUw3XkPhQodQ%3D' (2025-04-12)
• Updated input 'ghostty':
    'github:ghostty-org/ghostty/6f7977fef186faa9b9afe7707dc21a2eff59883b?narHash=sha256-URg5DLo0IvpTLNGrWA9f6U4pl21JxsQWSJUpjvALyxs%3D' (2025-04-05)
  → 'github:ghostty-org/ghostty/4aa875bbf641d9c31619217b3dc373d734986247?narHash=sha256-flGMRT7E4URVCj0o4bMfQlehJNrD/1mZy4OobfEwvq8%3D' (2025-04-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a9f8b3db211b4609ddd83683f9db89796c7f6ac6?narHash=sha256-2lDQBOmlz9ggPxcS7/GvcVdzXMIiT%2BPpMao6FbLJSr0%3D' (2025-04-04)
  → 'github:nix-community/home-manager/b4e98224ad1336751a2ac7493967a4c9f6d9cb3f?narHash=sha256-t7dFCDl4vIOOUMhEZnJF15aAzkpaup9x4ZRGToDFYWI%3D' (2025-04-08)
• Updated input 'neovim-flake':
    'github:nix-community/neovim-nightly-overlay/8c5c5d1c160110b186b1d6fe9c7302a82369d5f9?narHash=sha256-7sh2G01stnOdDHCcy1ELXeEGrQaCEQ5FH5cgkVr9G%2B8%3D' (2025-04-05)
  → 'github:nix-community/neovim-nightly-overlay/0d7c64d83bf26019292db406f1bfc62fb5f2bc3f?narHash=sha256-633XUO9ScY38cZUpgwLo5FylImxDYZvErh54CAfQSsc%3D' (2025-04-15)
• Updated input 'neovim-flake/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/524637ef84c177661690b924bf64a1ce18072a2c?narHash=sha256-I6fG1zrfdLFcp/imGZElig0BJO3YU0QEXLgvwWoOpJ8%3D' (2025-03-15)
  → 'github:hercules-ci/hercules-ci-effects/6eaa505af87705041ef2cf5534f5fc8fe88e94c2?narHash=sha256-PWcxJN2MoWCGC73KI93di2njqrashftWJ6w/fWTvdCM%3D' (2025-04-14)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/a8edf6e4459d7422c1a96e4f33e350090902dc61?narHash=sha256-Tg/bzD2vBjavOS4jUMQV60dwg5RzSpFsjQr/C3xbq9g%3D' (2025-04-04)
  → 'github:neovim/neovim/3341ab07764e9cda95e89880da579ea3ebb7f9b7?narHash=sha256-N/1NGAhjLg68kJJpdcccMbOkHZy0YY0HKnhs6TDDWU0%3D' (2025-04-14)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d?narHash=sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E%3D' (2025-03-30)
  → 'github:nix-community/nix-index-database/4fc9ea78c962904f4ea11046f3db37c62e8a02fd?narHash=sha256-RLBSWQfTL0v%2B7uyskC5kP6slLK1jvIuhaAh8QvB75m4%3D' (2025-04-13)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/de6fc5551121c59c01e2a3d45b277a6d05077bc4?narHash=sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo%3D' (2025-03-31)
  → 'github:nixos/nixos-hardware/9a049b4a421076d27fee3eec664a18b2066824cb?narHash=sha256-fbWE4Xpw6eH0Q6in%2BymNuDwTkqmFmtxcQEmtRuKDTTk%3D' (2025-04-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/bdb91860de2f719b57eef819b5617762f7120c70?narHash=sha256-s1KLDALEeqy%2BttrvqV3jx9mBZEvmthQErTVOAzbjHZs%3D' (2025-04-03)
  → 'github:nixos/nixpkgs/26d499fc9f1d567283d5d56fcf367edd815dba1d?narHash=sha256-FHlSkNqFmPxPJvy%2B6fNLaNeWnF1lZSgqVCl/eWaJRc4%3D' (2025-04-12)
• Updated input 'nur':
    'github:nix-community/nur/67f21fa057f77a3c2450df19165db7d56e8896ae?narHash=sha256-E1JS%2BGEkoPo9fgOE5E%2Bb5V7c1cq3OBDuaI9Kg6DRkHk%3D' (2025-04-05)
  → 'github:nix-community/nur/a0fd02eb827911d886114c9f2680df34ec0a6267?narHash=sha256-NRiuDkoCFap4GKb4UjtNqY2p6xnZl4/tRsPsP2m0kdg%3D' (2025-04-14)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434?narHash=sha256-F7n4%2BKOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE%3D' (2025-04-02)
  → 'github:nixos/nixpkgs/2631b0b7abcea6e640ce31cd78ea58910d31e650?narHash=sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR%2BXhw3kr/3Xd0GPTM%3D' (2025-04-12)
• Updated input 'nushell-src':
    'github:nushell/nushell/f25525be6cc0343d77f232f8ccecde25798d56aa?narHash=sha256-fAKeSvtO0fgyqwLDyzI50pIThO6ClPqYOEXL2W5%2BwHM%3D' (2025-04-05)
  → 'github:nushell/nushell/4e307480e4a5431053aa95750a733651c0200c59?narHash=sha256-e2Y%2B62kZ/5XXz7yubKkSKJnzFjjucdDxKvykmsoouB4%3D' (2025-04-14)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/b4734ce867252f92cdc7d25f8cc3b7cef153e703?narHash=sha256-UXxJogXhPhBFaX4uxmMudcD/x3sEGFtoSc4busTcftY%3D' (2025-04-05)
  → 'github:oxalica/rust-overlay/fd6795d3d28f956de01a0458b6fa7baae5c793b4?narHash=sha256-yzaDPkJwZdUtRj/dzdOeB74yryWzpngYaD7BedqFKk8%3D' (2025-04-14)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`67f21fa0` ➡️ `a0fd02eb`](https://github.com/nix-community/nur/compare/67f21fa057f77a3c2450df19165db7d56e8896ae...a0fd02eb827911d886114c9f2680df34ec0a6267) <sub>(2025-04-05 to 2025-04-14)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`a8edf6e4` ➡️ `3341ab07`](https://github.com/neovim/neovim/compare/a8edf6e4459d7422c1a96e4f33e350090902dc61...3341ab07764e9cda95e89880da579ea3ebb7f9b7) <sub>(2025-04-04 to 2025-04-14)</sub>
 - Updated input [`darwin`](https://github.com/lnl7/nix-darwin): [`73d59580` ➡️ `43975d78`](https://github.com/lnl7/nix-darwin/compare/73d59580d01e9b9f957ba749f336a272869c42dd...43975d782b418ebf4969e9ccba82466728c2851b) <sub>(2025-04-01 to 2025-04-12)</sub>
 - Updated input [`nix-index-database`](https://github.com/nix-community/nix-index-database): [`b3696bfb` ➡️ `4fc9ea78`](https://github.com/nix-community/nix-index-database/compare/b3696bfb6c24aa61428839a99e8b40c53ac3a82d...4fc9ea78c962904f4ea11046f3db37c62e8a02fd) <sub>(2025-03-30 to 2025-04-13)</sub>
 - Updated input [`neovim-flake/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`524637ef` ➡️ `6eaa505a`](https://github.com/hercules-ci/hercules-ci-effects/compare/524637ef84c177661690b924bf64a1ce18072a2c...6eaa505af87705041ef2cf5534f5fc8fe88e94c2) <sub>(2025-03-15 to 2025-04-14)</sub>
 - Updated input [`nur/nixpkgs`](https://github.com/nixos/nixpkgs): [`2c8d3f48` ➡️ `2631b0b7`](https://github.com/nixos/nixpkgs/compare/2c8d3f48d33929642c1c12cd243df4cc7d2ce434...2631b0b7abcea6e640ce31cd78ea58910d31e650) <sub>(2025-04-02 to 2025-04-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`bdb91860` ➡️ `26d499fc`](https://github.com/nixos/nixpkgs/compare/bdb91860de2f719b57eef819b5617762f7120c70...26d499fc9f1d567283d5d56fcf367edd815dba1d) <sub>(2025-04-03 to 2025-04-12)</sub>
 - Updated input [`ghostty`](https://github.com/ghostty-org/ghostty): [`6f7977fe` ➡️ `4aa875bb`](https://github.com/ghostty-org/ghostty/compare/6f7977fef186faa9b9afe7707dc21a2eff59883b...4aa875bbf641d9c31619217b3dc373d734986247) <sub>(2025-04-05 to 2025-04-14)</sub>
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`8c5c5d1c` ➡️ `0d7c64d8`](https://github.com/nix-community/neovim-nightly-overlay/compare/8c5c5d1c160110b186b1d6fe9c7302a82369d5f9...0d7c64d83bf26019292db406f1bfc62fb5f2bc3f) <sub>(2025-04-05 to 2025-04-15)</sub>
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`b4734ce8` ➡️ `fd6795d3`](https://github.com/oxalica/rust-overlay/compare/b4734ce867252f92cdc7d25f8cc3b7cef153e703...fd6795d3d28f956de01a0458b6fa7baae5c793b4) <sub>(2025-04-05 to 2025-04-14)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`a9f8b3db` ➡️ `b4e98224`](https://github.com/nix-community/home-manager/compare/a9f8b3db211b4609ddd83683f9db89796c7f6ac6...b4e98224ad1336751a2ac7493967a4c9f6d9cb3f) <sub>(2025-04-04 to 2025-04-08)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`f25525be` ➡️ `4e307480`](https://github.com/nushell/nushell/compare/f25525be6cc0343d77f232f8ccecde25798d56aa...4e307480e4a5431053aa95750a733651c0200c59) <sub>(2025-04-05 to 2025-04-14)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`de6fc555` ➡️ `9a049b4a`](https://github.com/nixos/nixos-hardware/compare/de6fc5551121c59c01e2a3d45b277a6d05077bc4...9a049b4a421076d27fee3eec664a18b2066824cb) <sub>(2025-03-31 to 2025-04-14)</sub>