### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747752302,
-        "narHash": "sha256-XqNAcEFfe5tJZGlx+Su0G67ZwRwZmHNWwiMK0fji0Hw=",
+        "lastModified": 1749744770,
+        "narHash": "sha256-MEM9XXHgBF/Cyv1RES1t6gqAX7/tvayBC1r/KPyK1ls=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "74ecd01d2c122f8a4a48066ab1d48f3e01671671",
+        "rev": "536f951efb1ccda9b968e3c9dee39fbeb6d3fdeb",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -170,17 +170,16 @@
       "inputs": {
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils",
-        "nixpkgs-stable": "nixpkgs-stable",
-        "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs": "nixpkgs",
         "zig": "zig",
         "zon2nix": "zon2nix"
       },
       "locked": {
-        "lastModified": 1743820100,
-        "narHash": "sha256-URg5DLo0IvpTLNGrWA9f6U4pl21JxsQWSJUpjvALyxs=",
+        "lastModified": 1752328988,
+        "narHash": "sha256-07BUaMjLkaSjUgVhlSrbODF+OZHCck5PeGvbtq6wQaA=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "6f7977fef186faa9b9afe7707dc21a2eff59883b",
+        "rev": "b5000dcd94b75d745dacbcd3d4bfaf181d288671",
         "type": "github"
       },
       "original": {
@@ -199,11 +198,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {
@@ -243,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742014779,
-        "narHash": "sha256-I6fG1zrfdLFcp/imGZElig0BJO3YU0QEXLgvwWoOpJ8=",
+        "lastModified": 1748000383,
+        "narHash": "sha256-EaAJhwfJGBncgIV/0NlJviid2DP93cTMc9h0q6P6xXk=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "524637ef84c177661690b924bf64a1ce18072a2c",
+        "rev": "231726642197817d20310b9d39dd4afb9e899489",
         "type": "github"
       },
       "original": {
@@ -263,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747556831,
-        "narHash": "sha256-Qb84nbYFFk0DzFeqVoHltS2RodAYY5/HZQKE8WnBDsc=",
+        "lastModified": 1752391422,
+        "narHash": "sha256-ReX0NG6nIAEtQQjLqeu1vUU2jjZuMlpymNtb4VQYeus=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0bbd221482c2713cccb80220f3c9d16a6e20a33",
+        "rev": "c26266790678863cce8e7460fdbf0d80991b1906",
         "type": "github"
       },
       "original": {
@@ -290,11 +289,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1743825774,
-        "narHash": "sha256-7sh2G01stnOdDHCcy1ELXeEGrQaCEQ5FH5cgkVr9G+8=",
+        "lastModified": 1752410216,
+        "narHash": "sha256-K7o6VJIJcsvOlwTlTYNvx35sJfa3fCohm+E/0bZAkOk=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "8c5c5d1c160110b186b1d6fe9c7302a82369d5f9",
+        "rev": "1ac62e7c19554b7effab140bb0ba4dc1a4ec3f49",
         "type": "github"
       },
       "original": {
@@ -306,11 +305,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1743773673,
-        "narHash": "sha256-Tg/bzD2vBjavOS4jUMQV60dwg5RzSpFsjQr/C3xbq9g=",
+        "lastModified": 1752364558,
+        "narHash": "sha256-EWU2n2NQXcqKdGcwyouLa1MFVXu97Lg9oqKC+TjP6U0=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a8edf6e4459d7422c1a96e4f33e350090902dc61",
+        "rev": "4778a4c201793141329cf58bb52a6fcc1d9c9eb1",
         "type": "github"
       },
       "original": {
@@ -326,11 +325,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743306489,
-        "narHash": "sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E=",
+        "lastModified": 1752378829,
+        "narHash": "sha256-LVqpSiYJ+zcxLvA6YUn9udrq8+NFBJ9oSwiEePPa9+g=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "b3696bfb6c24aa61428839a99e8b40c53ac3a82d",
+        "rev": "12201a430ee613bc720cef21a130b416cb1b5108",
         "type": "github"
       },
       "original": {
@@ -341,11 +340,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1743420942,
-        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
+        "lastModified": 1752048960,
+        "narHash": "sha256-gATnkOe37eeVwKKYCsL+OnS2gU4MmLuZFzzWCtaKLI8=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
+        "rev": "7ced9122cff2163c6a0212b8d1ec8c33a1660806",
         "type": "github"
       },
       "original": {
@@ -356,11 +355,24 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747825515,
-        "narHash": "sha256-BWpMQymVI73QoKZdcVCxUCCK3GNvr/xa2Dc4DM1o2BE=",
+        "lastModified": 1748189127,
+        "narHash": "sha256-zRDR+EbbeObu4V2X5QCd2Bk5eltfDlCr5yvhBwUT6pY=",
+        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/25.05/nixos-25.05.802491.7c43f080a7f2/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1752308619,
+        "narHash": "sha256-pzrVLKRQNPrii06Rm09Q0i0dq3wt2t2pciT/GNq5EZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd2812de55cf87df88a9e09bf3be1ce63d50c1a6",
+        "rev": "650e572363c091045cdbc5b36b0f4c1f614d3058",
         "type": "github"
       },
       "original": {
@@ -370,45 +382,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
+    "nixpkgs_3": {
       "locked": {
-        "lastModified": 1741992157,
-        "narHash": "sha256-nlIfTsTrMSksEJc1f7YexXiPVuzD1gOfeN1ggwZyUoc=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da4b122f63095ca1199bd4d526f9e26426697689",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1741865919,
-        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {
@@ -421,15 +401,14 @@
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_2",
-        "treefmt-nix": "treefmt-nix_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1743867911,
-        "narHash": "sha256-E1JS+GEkoPo9fgOE5E+b5V7c1cq3OBDuaI9Kg6DRkHk=",
+        "lastModified": 1752427073,
+        "narHash": "sha256-DliA3hYugofFvOnZic5m1ANOB0ZUTi4clBIf2vFrjRo=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "67f21fa057f77a3c2450df19165db7d56e8896ae",
+        "rev": "b97cb16b7933784d83a660731a6d6d833a969ebd",
         "type": "github"
       },
       "original": {
@@ -441,11 +420,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1743863056,
-        "narHash": "sha256-fAKeSvtO0fgyqwLDyzI50pIThO6ClPqYOEXL2W5+wHM=",
+        "lastModified": 1752425635,
+        "narHash": "sha256-xt1KK2i+F3559n/LjPuMT/Ps9nPc717Z6k6NrpVORnc=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "f25525be6cc0343d77f232f8ccecde25798d56aa",
+        "rev": "bfe9d8699d8b0fee9a7c570d7cd26f761054a76a",
         "type": "github"
       },
       "original": {
@@ -463,11 +442,11 @@
         "neovim-flake": "neovim-flake",
         "nix-index-database": "nix-index-database",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nur": "nur",
         "nushell-src": "nushell-src",
         "rust-overlay": "rust-overlay",
-        "treefmt-nix": "treefmt-nix_3"
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "rust-overlay": {
@@ -477,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743820323,
-        "narHash": "sha256-UXxJogXhPhBFaX4uxmMudcD/x3sEGFtoSc4busTcftY=",
+        "lastModified": 1752374969,
+        "narHash": "sha256-Ky3ynEkJXih7mvWyt9DWoiSiZGqPeHLU1tlBU4b0mcc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b4734ce867252f92cdc7d25f8cc3b7cef153e703",
+        "rev": "75fb000638e6d0f57cb1e8b7a4550cbdd8c76f1d",
         "type": "github"
       },
       "original": {
@@ -513,11 +492,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743748085,
-        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
+        "lastModified": 1752055615,
+        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
+        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
         "type": "github"
       },
       "original": {
@@ -529,36 +508,15 @@
     "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
-          "nur",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1733222881,
-        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "lastModified": 1752055615,
+        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1747469671,
-        "narHash": "sha256-bo1ptiFoNqm6m1B2iAhJmWCBmqveLVvxom6xKmtuzjg=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
+        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
         "type": "github"
       },
       "original": {
@@ -578,15 +536,15 @@
         ],
         "nixpkgs": [
           "ghostty",
-          "nixpkgs-stable"
+          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1741825901,
-        "narHash": "sha256-aeopo+aXg5I2IksOPFN79usw7AeimH1+tjfuMzJHFdk=",
+        "lastModified": 1748261582,
+        "narHash": "sha256-3i0IL3s18hdDlbsf0/E+5kyPRkZwGPbSFngq5eToiAA=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "0b14285e283f5a747f372fb2931835dd937c4383",
+        "rev": "aafb1b093fb838f7a02613b719e85ec912914221",
         "type": "github"
       },
       "original": {
@@ -603,7 +561,7 @@
         ],
         "nixpkgs": [
           "ghostty",
-          "nixpkgs-unstable"
+          "nixpkgs"
         ]
       },
       "locked": {

--- a/home/profiles/common.nix
+++ b/home/profiles/common.nix
@@ -8,7 +8,7 @@
 with lib; let
   cfg = config.nyx.profiles.common;
 in {
-  imports = [inputs.nix-index-database.hmModules.nix-index];
+  imports = [inputs.nix-index-database.homeModules.nix-index];
 
   options.nyx.profiles.common = {enable = mkEnableOption "common profile";};
 


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'darwin':
    'github:nix-darwin/nix-darwin/74ecd01d2c122f8a4a48066ab1d48f3e01671671?narHash=sha256-XqNAcEFfe5tJZGlx%2BSu0G67ZwRwZmHNWwiMK0fji0Hw%3D' (2025-05-20)
  → 'github:nix-darwin/nix-darwin/536f951efb1ccda9b968e3c9dee39fbeb6d3fdeb?narHash=sha256-MEM9XXHgBF/Cyv1RES1t6gqAX7/tvayBC1r/KPyK1ls%3D' (2025-06-12)
• Updated input 'flake-compat':
    'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
  → 'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
• Updated input 'ghostty':
    'github:ghostty-org/ghostty/6f7977fef186faa9b9afe7707dc21a2eff59883b?narHash=sha256-URg5DLo0IvpTLNGrWA9f6U4pl21JxsQWSJUpjvALyxs%3D' (2025-04-05)
  → 'github:ghostty-org/ghostty/b5000dcd94b75d745dacbcd3d4bfaf181d288671?narHash=sha256-07BUaMjLkaSjUgVhlSrbODF%2BOZHCck5PeGvbtq6wQaA%3D' (2025-07-12)
• Updated input 'ghostty/flake-compat':
    'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
  → 'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
• Added input 'ghostty/nixpkgs':
    'https://releases.nixos.org/nixos/25.05/nixos-25.05.802491.7c43f080a7f2/nixexprs.tar.xz?narHash=sha256-zRDR%2BEbbeObu4V2X5QCd2Bk5eltfDlCr5yvhBwUT6pY%3D' (2025-05-25)
• Removed input 'ghostty/nixpkgs-stable'
• Removed input 'ghostty/nixpkgs-unstable'
• Updated input 'ghostty/zig':
    'github:mitchellh/zig-overlay/0b14285e283f5a747f372fb2931835dd937c4383?narHash=sha256-aeopo%2BaXg5I2IksOPFN79usw7AeimH1%2BtjfuMzJHFdk%3D' (2025-03-13)
  → 'github:mitchellh/zig-overlay/aafb1b093fb838f7a02613b719e85ec912914221?narHash=sha256-3i0IL3s18hdDlbsf0/E%2B5kyPRkZwGPbSFngq5eToiAA%3D' (2025-05-26)
• Updated input 'ghostty/zig/nixpkgs':
    follows 'ghostty/nixpkgs-stable'
  → follows 'ghostty/nixpkgs'
• Updated input 'ghostty/zon2nix/nixpkgs':
    follows 'ghostty/nixpkgs-unstable'
  → follows 'ghostty/nixpkgs'
• Updated input 'home-manager':
    'github:nix-community/home-manager/d0bbd221482c2713cccb80220f3c9d16a6e20a33?narHash=sha256-Qb84nbYFFk0DzFeqVoHltS2RodAYY5/HZQKE8WnBDsc%3D' (2025-05-18)
  → 'github:nix-community/home-manager/c26266790678863cce8e7460fdbf0d80991b1906?narHash=sha256-ReX0NG6nIAEtQQjLqeu1vUU2jjZuMlpymNtb4VQYeus%3D' (2025-07-13)
• Updated input 'neovim-flake':
    'github:nix-community/neovim-nightly-overlay/8c5c5d1c160110b186b1d6fe9c7302a82369d5f9?narHash=sha256-7sh2G01stnOdDHCcy1ELXeEGrQaCEQ5FH5cgkVr9G%2B8%3D' (2025-04-05)
  → 'github:nix-community/neovim-nightly-overlay/1ac62e7c19554b7effab140bb0ba4dc1a4ec3f49?narHash=sha256-K7o6VJIJcsvOlwTlTYNvx35sJfa3fCohm%2BE/0bZAkOk%3D' (2025-07-13)
• Updated input 'neovim-flake/flake-compat':
    'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec?narHash=sha256-NeCCThCEP3eCl2l/%2B27kNNK7QrwZB1IJCrXfrbv5oqU%3D' (2024-12-04)
  → 'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
• Updated input 'neovim-flake/flake-parts':
    'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
  → 'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5?narHash=sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ%3D' (2025-07-01)
• Updated input 'neovim-flake/git-hooks':
    'github:cachix/git-hooks.nix/dcf5072734cb576d2b0c59b2ac44f5050b5eac82?narHash=sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco%3D' (2025-03-22)
  → 'github:cachix/git-hooks.nix/16ec914f6fb6f599ce988427d9d94efddf25fe6d?narHash=sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg%3D' (2025-06-24)
• Updated input 'neovim-flake/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/524637ef84c177661690b924bf64a1ce18072a2c?narHash=sha256-I6fG1zrfdLFcp/imGZElig0BJO3YU0QEXLgvwWoOpJ8%3D' (2025-03-15)
  → 'github:hercules-ci/hercules-ci-effects/231726642197817d20310b9d39dd4afb9e899489?narHash=sha256-EaAJhwfJGBncgIV/0NlJviid2DP93cTMc9h0q6P6xXk%3D' (2025-05-23)
• Updated input 'neovim-flake/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9?narHash=sha256-%2Bu2UunDA4Cl5Fci3m7S643HzKmIDAe%2BfiXrLqYsR2fs%3D' (2025-03-07)
  → 'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/a8edf6e4459d7422c1a96e4f33e350090902dc61?narHash=sha256-Tg/bzD2vBjavOS4jUMQV60dwg5RzSpFsjQr/C3xbq9g%3D' (2025-04-04)
  → 'github:neovim/neovim/4778a4c201793141329cf58bb52a6fcc1d9c9eb1?narHash=sha256-EWU2n2NQXcqKdGcwyouLa1MFVXu97Lg9oqKC%2BTjP6U0%3D' (2025-07-12)
• Updated input 'neovim-flake/treefmt-nix':
    'github:numtide/treefmt-nix/815e4121d6a5d504c0f96e5be2dd7f871e4fd99d?narHash=sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660%2BgbUU3cE%3D' (2025-04-04)
  → 'github:numtide/treefmt-nix/c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9?narHash=sha256-19m7P4O/Aw/6%2BCzncWMAJu89JaKeMh3aMle1CNQSIwM%3D' (2025-07-09)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/b3696bfb6c24aa61428839a99e8b40c53ac3a82d?narHash=sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E%3D' (2025-03-30)
  → 'github:nix-community/nix-index-database/12201a430ee613bc720cef21a130b416cb1b5108?narHash=sha256-LVqpSiYJ%2BzcxLvA6YUn9udrq8%2BNFBJ9oSwiEePPa9%2Bg%3D' (2025-07-13)
• Updated input 'nixos-hardware':
    'github:nixos/nixos-hardware/de6fc5551121c59c01e2a3d45b277a6d05077bc4?narHash=sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo%3D' (2025-03-31)
  → 'github:nixos/nixos-hardware/7ced9122cff2163c6a0212b8d1ec8c33a1660806?narHash=sha256-gATnkOe37eeVwKKYCsL%2BOnS2gU4MmLuZFzzWCtaKLI8%3D' (2025-07-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/cd2812de55cf87df88a9e09bf3be1ce63d50c1a6?narHash=sha256-BWpMQymVI73QoKZdcVCxUCCK3GNvr/xa2Dc4DM1o2BE%3D' (2025-05-21)
  → 'github:nixos/nixpkgs/650e572363c091045cdbc5b36b0f4c1f614d3058?narHash=sha256-pzrVLKRQNPrii06Rm09Q0i0dq3wt2t2pciT/GNq5EZQ%3D' (2025-07-12)
• Updated input 'nur':
    'github:nix-community/nur/67f21fa057f77a3c2450df19165db7d56e8896ae?narHash=sha256-E1JS%2BGEkoPo9fgOE5E%2Bb5V7c1cq3OBDuaI9Kg6DRkHk%3D' (2025-04-05)
  → 'github:nix-community/nur/b97cb16b7933784d83a660731a6d6d833a969ebd?narHash=sha256-DliA3hYugofFvOnZic5m1ANOB0ZUTi4clBIf2vFrjRo%3D' (2025-07-13)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434?narHash=sha256-F7n4%2BKOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE%3D' (2025-04-02)
  → 'github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0?narHash=sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X%2BxgOL0%3D' (2025-07-08)
• Removed input 'nur/treefmt-nix'
• Removed input 'nur/treefmt-nix/nixpkgs'
• Updated input 'nushell-src':
    'github:nushell/nushell/f25525be6cc0343d77f232f8ccecde25798d56aa?narHash=sha256-fAKeSvtO0fgyqwLDyzI50pIThO6ClPqYOEXL2W5%2BwHM%3D' (2025-04-05)
  → 'github:nushell/nushell/bfe9d8699d8b0fee9a7c570d7cd26f761054a76a?narHash=sha256-xt1KK2i%2BF3559n/LjPuMT/Ps9nPc717Z6k6NrpVORnc%3D' (2025-07-13)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/b4734ce867252f92cdc7d25f8cc3b7cef153e703?narHash=sha256-UXxJogXhPhBFaX4uxmMudcD/x3sEGFtoSc4busTcftY%3D' (2025-04-05)
  → 'github:oxalica/rust-overlay/75fb000638e6d0f57cb1e8b7a4550cbdd8c76f1d?narHash=sha256-Ky3ynEkJXih7mvWyt9DWoiSiZGqPeHLU1tlBU4b0mcc%3D' (2025-07-13)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb?narHash=sha256-bo1ptiFoNqm6m1B2iAhJmWCBmqveLVvxom6xKmtuzjg%3D' (2025-05-17)
  → 'github:numtide/treefmt-nix/c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9?narHash=sha256-19m7P4O/Aw/6%2BCzncWMAJu89JaKeMh3aMle1CNQSIwM%3D' (2025-07-09)

```

</p></details>

 - Added input `ghostty/nixpkgs`: `https://releases.nixos.org/nixos/25.05/nixos-25.05.802491.7c43f080a7f2/nixexprs.tar.xz?narHash=sha256-zRDR%2BEbbeObu4V2X5QCd2Bk5eltfDlCr5yvhBwUT6pY%3D`
 - Updated input [`ghostty/flake-compat`](https://github.com/edolstra/flake-compat): [`ff81ac96` ➡️ `9100a0f4`](https://github.com/edolstra/flake-compat/compare/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec...9100a0f413b0c601e0533d1d94ffd501ce2e7885) <sub>(2024-12-04 to 2025-05-12)</sub>
 - Removed input `nur/treefmt-nix/nixpkgs`.
 - Updated input [`nur`](https://github.com/nix-community/nur): [`67f21fa0` ➡️ `b97cb16b`](https://github.com/nix-community/nur/compare/67f21fa057f77a3c2450df19165db7d56e8896ae...b97cb16b7933784d83a660731a6d6d833a969ebd) <sub>(2025-04-05 to 2025-07-13)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`a8edf6e4` ➡️ `4778a4c2`](https://github.com/neovim/neovim/compare/a8edf6e4459d7422c1a96e4f33e350090902dc61...4778a4c201793141329cf58bb52a6fcc1d9c9eb1) <sub>(2025-04-04 to 2025-07-12)</sub>
 - Updated input [`darwin`](https://github.com/nix-darwin/nix-darwin): [`74ecd01d` ➡️ `536f951e`](https://github.com/nix-darwin/nix-darwin/compare/74ecd01d2c122f8a4a48066ab1d48f3e01671671...536f951efb1ccda9b968e3c9dee39fbeb6d3fdeb) <sub>(2025-05-20 to 2025-06-12)</sub>
 - Updated input [`neovim-flake/flake-compat`](https://github.com/edolstra/flake-compat): [`ff81ac96` ➡️ `9100a0f4`](https://github.com/edolstra/flake-compat/compare/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec...9100a0f413b0c601e0533d1d94ffd501ce2e7885) <sub>(2024-12-04 to 2025-05-12)</sub>
 - Updated input `ghostty/zon2nix/nixpkgs`: `` ➡️ `` <sub>( to )</sub>
 - Updated input [`treefmt-nix`](https://github.com/numtide/treefmt-nix): [`ab0378b6` ➡️ `c9d477b5`](https://github.com/numtide/treefmt-nix/compare/ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb...c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9) <sub>(2025-05-17 to 2025-07-09)</sub>
 - Updated input [`nix-index-database`](https://github.com/nix-community/nix-index-database): [`b3696bfb` ➡️ `12201a43`](https://github.com/nix-community/nix-index-database/compare/b3696bfb6c24aa61428839a99e8b40c53ac3a82d...12201a430ee613bc720cef21a130b416cb1b5108) <sub>(2025-03-30 to 2025-07-13)</sub>
 - Updated input [`neovim-flake/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`815e4121` ➡️ `c9d477b5`](https://github.com/numtide/treefmt-nix/compare/815e4121d6a5d504c0f96e5be2dd7f871e4fd99d...c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9) <sub>(2025-04-04 to 2025-07-09)</sub>
 - Updated input [`neovim-flake/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`524637ef` ➡️ `23172664`](https://github.com/hercules-ci/hercules-ci-effects/compare/524637ef84c177661690b924bf64a1ce18072a2c...231726642197817d20310b9d39dd4afb9e899489) <sub>(2025-03-15 to 2025-05-23)</sub>
 - Updated input [`neovim-flake/git-hooks`](https://github.com/cachix/git-hooks.nix): [`dcf50727` ➡️ `16ec914f`](https://github.com/cachix/git-hooks.nix/compare/dcf5072734cb576d2b0c59b2ac44f5050b5eac82...16ec914f6fb6f599ce988427d9d94efddf25fe6d) <sub>(2025-03-22 to 2025-06-24)</sub>
 - Updated input `ghostty/zig/nixpkgs`: `` ➡️ `` <sub>( to )</sub>
 - Removed input `nur/treefmt-nix`.
 - Updated input [`nur/nixpkgs`](https://github.com/nixos/nixpkgs): [`2c8d3f48` ➡️ `9807714d`](https://github.com/nixos/nixpkgs/compare/2c8d3f48d33929642c1c12cd243df4cc7d2ce434...9807714d6944a957c2e036f84b0ff8caf9930bc0) <sub>(2025-04-02 to 2025-07-08)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`cd2812de` ➡️ `650e5723`](https://github.com/nixos/nixpkgs/compare/cd2812de55cf87df88a9e09bf3be1ce63d50c1a6...650e572363c091045cdbc5b36b0f4c1f614d3058) <sub>(2025-05-21 to 2025-07-12)</sub>
 - Updated input [`neovim-flake/flake-parts`](https://github.com/hercules-ci/flake-parts): [`c621e842` ➡️ `77826244`](https://github.com/hercules-ci/flake-parts/compare/c621e8422220273271f52058f618c94e405bb0f5...77826244401ea9de6e3bac47c2db46005e1f30b5) <sub>(2025-04-01 to 2025-07-01)</sub>
 - Updated input [`ghostty/zig`](https://github.com/mitchellh/zig-overlay): [`0b14285e` ➡️ `aafb1b09`](https://github.com/mitchellh/zig-overlay/compare/0b14285e283f5a747f372fb2931835dd937c4383...aafb1b093fb838f7a02613b719e85ec912914221) <sub>(2025-03-13 to 2025-05-26)</sub>
 - Removed input `ghostty/nixpkgs-stable`.
 - Updated input [`ghostty`](https://github.com/ghostty-org/ghostty): [`6f7977fe` ➡️ `b5000dcd`](https://github.com/ghostty-org/ghostty/compare/6f7977fef186faa9b9afe7707dc21a2eff59883b...b5000dcd94b75d745dacbcd3d4bfaf181d288671) <sub>(2025-04-05 to 2025-07-12)</sub>
 - Updated input [`flake-compat`](https://github.com/edolstra/flake-compat): [`ff81ac96` ➡️ `9100a0f4`](https://github.com/edolstra/flake-compat/compare/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec...9100a0f413b0c601e0533d1d94ffd501ce2e7885) <sub>(2024-12-04 to 2025-05-12)</sub>
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`8c5c5d1c` ➡️ `1ac62e7c`](https://github.com/nix-community/neovim-nightly-overlay/compare/8c5c5d1c160110b186b1d6fe9c7302a82369d5f9...1ac62e7c19554b7effab140bb0ba4dc1a4ec3f49) <sub>(2025-04-05 to 2025-07-13)</sub>
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`b4734ce8` ➡️ `75fb0006`](https://github.com/oxalica/rust-overlay/compare/b4734ce867252f92cdc7d25f8cc3b7cef153e703...75fb000638e6d0f57cb1e8b7a4550cbdd8c76f1d) <sub>(2025-04-05 to 2025-07-13)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`d0bbd221` ➡️ `c2626679`](https://github.com/nix-community/home-manager/compare/d0bbd221482c2713cccb80220f3c9d16a6e20a33...c26266790678863cce8e7460fdbf0d80991b1906) <sub>(2025-05-18 to 2025-07-13)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`f25525be` ➡️ `bfe9d869`](https://github.com/nushell/nushell/compare/f25525be6cc0343d77f232f8ccecde25798d56aa...bfe9d8699d8b0fee9a7c570d7cd26f761054a76a) <sub>(2025-04-05 to 2025-07-13)</sub>
 - Updated input [`nixos-hardware`](https://github.com/nixos/nixos-hardware): [`de6fc555` ➡️ `7ced9122`](https://github.com/nixos/nixos-hardware/compare/de6fc5551121c59c01e2a3d45b277a6d05077bc4...7ced9122cff2163c6a0212b8d1ec8c33a1660806) <sub>(2025-03-31 to 2025-07-09)</sub>
 - Updated input [`neovim-flake/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [`f4330d22` ➡️ `c621e842`](https://github.com/hercules-ci/flake-parts/compare/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9...c621e8422220273271f52058f618c94e405bb0f5) <sub>(2025-03-07 to 2025-04-01)</sub>
 - Removed input `ghostty/nixpkgs-unstable`.