### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -175,11 +175,11 @@
         "zon2nix": "zon2nix"
       },
       "locked": {
-        "lastModified": 1752328988,
-        "narHash": "sha256-07BUaMjLkaSjUgVhlSrbODF+OZHCck5PeGvbtq6wQaA=",
+        "lastModified": 1752524958,
+        "narHash": "sha256-zuLc5Mn3vFyb/VsAyUFSSDPoPaVnsLugnshYaQidFUU=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "b5000dcd94b75d745dacbcd3d4bfaf181d288671",
+        "rev": "c75c4a9685354f3a4049d1b45820337f38ca8825",
         "type": "github"
       },
       "original": {
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752391422,
-        "narHash": "sha256-ReX0NG6nIAEtQQjLqeu1vUU2jjZuMlpymNtb4VQYeus=",
+        "lastModified": 1752527596,
+        "narHash": "sha256-kn620ocx9JmmWKBN4X+kTbsQg/nv2HBxceDf2zV08VM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c26266790678863cce8e7460fdbf0d80991b1906",
+        "rev": "8597e85e2ce33e6a6f1df99cc56cdf7680cb22e0",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1752410216,
-        "narHash": "sha256-K7o6VJIJcsvOlwTlTYNvx35sJfa3fCohm+E/0bZAkOk=",
+        "lastModified": 1752452414,
+        "narHash": "sha256-udMozuexr4XGAl1Wyt8A7apk9SqkAQZ9q3JvQ7wDKYM=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "1ac62e7c19554b7effab140bb0ba4dc1a4ec3f49",
+        "rev": "37319e0cdc7e966294b19c8780e13c6b533b369c",
         "type": "github"
       },
       "original": {
@@ -305,11 +305,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1752364558,
-        "narHash": "sha256-EWU2n2NQXcqKdGcwyouLa1MFVXu97Lg9oqKC+TjP6U0=",
+        "lastModified": 1752448282,
+        "narHash": "sha256-SUoypRHGYybA74JMaX0C+SLpBN+KrlxMK7GaBLTarfU=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "4778a4c201793141329cf58bb52a6fcc1d9c9eb1",
+        "rev": "9f16b598f943dc35539552a0c59c2c3b9aaca954",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752378829,
-        "narHash": "sha256-LVqpSiYJ+zcxLvA6YUn9udrq8+NFBJ9oSwiEePPa9+g=",
+        "lastModified": 1752441837,
+        "narHash": "sha256-FMH1OSSJp8Cx8MZHXz6KckxJGbCnVMotZNAH3v2WneU=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "12201a430ee613bc720cef21a130b416cb1b5108",
+        "rev": "839e02dece5845be3a322e507a79712b73a96ba2",
         "type": "github"
       },
       "original": {
@@ -404,11 +404,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1752427073,
-        "narHash": "sha256-DliA3hYugofFvOnZic5m1ANOB0ZUTi4clBIf2vFrjRo=",
+        "lastModified": 1752538836,
+        "narHash": "sha256-ZaWW5wtosFPbtwvnAzMLTjY1SdGhP637zzF40gzYhOs=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "b97cb16b7933784d83a660731a6d6d833a969ebd",
+        "rev": "37f575164cbcc08e29470a9e4b961e58b882efab",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
     "nushell-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1752425635,
-        "narHash": "sha256-xt1KK2i+F3559n/LjPuMT/Ps9nPc717Z6k6NrpVORnc=",
+        "lastModified": 1752543336,
+        "narHash": "sha256-H+G9EbPr061IF2r99YqJq+dNhRW3MGjCxdOigovvygw=",
         "owner": "nushell",
         "repo": "nushell",
-        "rev": "bfe9d8699d8b0fee9a7c570d7cd26f761054a76a",
+        "rev": "a506d3f9b5bef8ffdd1aa40ecfac29fe80dbc125",
         "type": "github"
       },
       "original": {
@@ -456,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752374969,
-        "narHash": "sha256-Ky3ynEkJXih7mvWyt9DWoiSiZGqPeHLU1tlBU4b0mcc=",
+        "lastModified": 1752461263,
+        "narHash": "sha256-f4XVgqkWF1vSzPbOG5xvi4aAd/n1GwSNsji3mLMFwYQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "75fb000638e6d0f57cb1e8b7a4550cbdd8c76f1d",
+        "rev": "9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad",
         "type": "github"
       },
       "original": {
@@ -528,7 +528,8 @@
     "zig": {
       "inputs": {
         "flake-compat": [
-          "ghostty"
+          "ghostty",
+          "flake-compat"
         ],
         "flake-utils": [
           "ghostty",
@@ -574,8 +575,8 @@
       },
       "original": {
         "owner": "jcollie",
-        "ref": "56c159be489cc6c0e73c3930bd908ddc6fe89613",
         "repo": "zon2nix",
+        "rev": "56c159be489cc6c0e73c3930bd908ddc6fe89613",
         "type": "github"
       }
     }


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'ghostty':
    'github:ghostty-org/ghostty/b5000dcd94b75d745dacbcd3d4bfaf181d288671?narHash=sha256-07BUaMjLkaSjUgVhlSrbODF%2BOZHCck5PeGvbtq6wQaA%3D' (2025-07-12)
  → 'github:ghostty-org/ghostty/c75c4a9685354f3a4049d1b45820337f38ca8825?narHash=sha256-zuLc5Mn3vFyb/VsAyUFSSDPoPaVnsLugnshYaQidFUU%3D' (2025-07-14)
• Updated input 'ghostty/zig/flake-compat':
    follows 'ghostty'
  → follows 'ghostty/flake-compat'
• Updated input 'home-manager':
    'github:nix-community/home-manager/c26266790678863cce8e7460fdbf0d80991b1906?narHash=sha256-ReX0NG6nIAEtQQjLqeu1vUU2jjZuMlpymNtb4VQYeus%3D' (2025-07-13)
  → 'github:nix-community/home-manager/8597e85e2ce33e6a6f1df99cc56cdf7680cb22e0?narHash=sha256-kn620ocx9JmmWKBN4X%2BkTbsQg/nv2HBxceDf2zV08VM%3D' (2025-07-14)
• Updated input 'neovim-flake':
    'github:nix-community/neovim-nightly-overlay/1ac62e7c19554b7effab140bb0ba4dc1a4ec3f49?narHash=sha256-K7o6VJIJcsvOlwTlTYNvx35sJfa3fCohm%2BE/0bZAkOk%3D' (2025-07-13)
  → 'github:nix-community/neovim-nightly-overlay/37319e0cdc7e966294b19c8780e13c6b533b369c?narHash=sha256-udMozuexr4XGAl1Wyt8A7apk9SqkAQZ9q3JvQ7wDKYM%3D' (2025-07-14)
• Updated input 'neovim-flake/neovim-src':
    'github:neovim/neovim/4778a4c201793141329cf58bb52a6fcc1d9c9eb1?narHash=sha256-EWU2n2NQXcqKdGcwyouLa1MFVXu97Lg9oqKC%2BTjP6U0%3D' (2025-07-12)
  → 'github:neovim/neovim/9f16b598f943dc35539552a0c59c2c3b9aaca954?narHash=sha256-SUoypRHGYybA74JMaX0C%2BSLpBN%2BKrlxMK7GaBLTarfU%3D' (2025-07-13)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/12201a430ee613bc720cef21a130b416cb1b5108?narHash=sha256-LVqpSiYJ%2BzcxLvA6YUn9udrq8%2BNFBJ9oSwiEePPa9%2Bg%3D' (2025-07-13)
  → 'github:nix-community/nix-index-database/839e02dece5845be3a322e507a79712b73a96ba2?narHash=sha256-FMH1OSSJp8Cx8MZHXz6KckxJGbCnVMotZNAH3v2WneU%3D' (2025-07-13)
• Updated input 'nur':
    'github:nix-community/nur/b97cb16b7933784d83a660731a6d6d833a969ebd?narHash=sha256-DliA3hYugofFvOnZic5m1ANOB0ZUTi4clBIf2vFrjRo%3D' (2025-07-13)
  → 'github:nix-community/nur/37f575164cbcc08e29470a9e4b961e58b882efab?narHash=sha256-ZaWW5wtosFPbtwvnAzMLTjY1SdGhP637zzF40gzYhOs%3D' (2025-07-15)
• Updated input 'nushell-src':
    'github:nushell/nushell/bfe9d8699d8b0fee9a7c570d7cd26f761054a76a?narHash=sha256-xt1KK2i%2BF3559n/LjPuMT/Ps9nPc717Z6k6NrpVORnc%3D' (2025-07-13)
  → 'github:nushell/nushell/a506d3f9b5bef8ffdd1aa40ecfac29fe80dbc125?narHash=sha256-H%2BG9EbPr061IF2r99YqJq%2BdNhRW3MGjCxdOigovvygw%3D' (2025-07-15)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/75fb000638e6d0f57cb1e8b7a4550cbdd8c76f1d?narHash=sha256-Ky3ynEkJXih7mvWyt9DWoiSiZGqPeHLU1tlBU4b0mcc%3D' (2025-07-13)
  → 'github:oxalica/rust-overlay/9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad?narHash=sha256-f4XVgqkWF1vSzPbOG5xvi4aAd/n1GwSNsji3mLMFwYQ%3D' (2025-07-14)

```

</p></details>

 - Updated input [`nur`](https://github.com/nix-community/nur): [`b97cb16b` ➡️ `37f57516`](https://github.com/nix-community/nur/compare/b97cb16b7933784d83a660731a6d6d833a969ebd...37f575164cbcc08e29470a9e4b961e58b882efab) <sub>(2025-07-13 to 2025-07-15)</sub>
 - Updated input [`neovim-flake/neovim-src`](https://github.com/neovim/neovim): [`4778a4c2` ➡️ `9f16b598`](https://github.com/neovim/neovim/compare/4778a4c201793141329cf58bb52a6fcc1d9c9eb1...9f16b598f943dc35539552a0c59c2c3b9aaca954) <sub>(2025-07-12 to 2025-07-13)</sub>
 - Updated input [`nix-index-database`](https://github.com/nix-community/nix-index-database): [`12201a43` ➡️ `839e02de`](https://github.com/nix-community/nix-index-database/compare/12201a430ee613bc720cef21a130b416cb1b5108...839e02dece5845be3a322e507a79712b73a96ba2) <sub>(2025-07-13 to 2025-07-13)</sub>
 - Updated input [`ghostty`](https://github.com/ghostty-org/ghostty): [`b5000dcd` ➡️ `c75c4a96`](https://github.com/ghostty-org/ghostty/compare/b5000dcd94b75d745dacbcd3d4bfaf181d288671...c75c4a9685354f3a4049d1b45820337f38ca8825) <sub>(2025-07-12 to 2025-07-14)</sub>
 - Updated input [`neovim-flake`](https://github.com/nix-community/neovim-nightly-overlay): [`1ac62e7c` ➡️ `37319e0c`](https://github.com/nix-community/neovim-nightly-overlay/compare/1ac62e7c19554b7effab140bb0ba4dc1a4ec3f49...37319e0cdc7e966294b19c8780e13c6b533b369c) <sub>(2025-07-13 to 2025-07-14)</sub>
 - Updated input [`rust-overlay`](https://github.com/oxalica/rust-overlay): [`75fb0006` ➡️ `9cc51d10`](https://github.com/oxalica/rust-overlay/compare/75fb000638e6d0f57cb1e8b7a4550cbdd8c76f1d...9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad) <sub>(2025-07-13 to 2025-07-14)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c2626679` ➡️ `8597e85e`](https://github.com/nix-community/home-manager/compare/c26266790678863cce8e7460fdbf0d80991b1906...8597e85e2ce33e6a6f1df99cc56cdf7680cb22e0) <sub>(2025-07-13 to 2025-07-14)</sub>
 - Updated input [`nushell-src`](https://github.com/nushell/nushell): [`bfe9d869` ➡️ `a506d3f9`](https://github.com/nushell/nushell/compare/bfe9d8699d8b0fee9a7c570d7cd26f761054a76a...a506d3f9b5bef8ffdd1aa40ecfac29fe80dbc125) <sub>(2025-07-13 to 2025-07-15)</sub>
 - Updated input `ghostty/zig/flake-compat`: `` ➡️ `` <sub>( to )</sub>